### PR TITLE
Added customToolFrameTF() function to address Issue #20.

### DIFF
--- a/moveit_simple/include/moveit_simple/moveit_simple.h
+++ b/moveit_simple/include/moveit_simple/moveit_simple.h
@@ -41,8 +41,6 @@
 #include <control_msgs/FollowJointTrajectoryAction.h>
 #include <sensor_msgs/JointState.h>
 
-
-
 namespace moveit_simple
 {
 
@@ -177,6 +175,29 @@ public:
   bool getJointSolution(const Eigen::Affine3d & pose, double timeout,
                         const std::vector<double> & seed,
                         std::vector<double> & joint_point) const;
+
+  /**
+   * @brief getJointSolution returns joint solution for cartesian pose.
+   * @brief This function supports custom tool frame for solving IK.
+   * @param pose - desired pose
+   * @param custom_tool_frame - custom frame id
+   * @param timeout - ik solver timeout
+   * @param attempts - number of IK solve attem
+   * @param seed - ik seed
+   * @param joint_point - joint solution for pose
+   * @return true if joint solution found
+   */
+  bool getJointSolution(const Eigen::Affine3d &pose, const std::string& custom_tool_frame,
+                        double timeout, const std::vector<double> & seed,
+                        std::vector<double> & joint_point) const;
+
+  /**
+   * @brief customToolFrameTF transforms custom frame to moveit_end_link.
+   * @param target_pose - goal pose for IK 
+   * @param frame - custom frame id
+   */
+  Eigen::Affine3d customToolFrameTF(const Eigen::Affine3d &target_pose, 
+                                    const std::string& frame) const;
 
   /**
    * @brief getPose finds cartesian pose for the given joint positions.
@@ -323,6 +344,7 @@ protected:
   bool getFK(const std::vector<double> & joint_point,
                                Eigen::Affine3d &pose) const;
 
+  /*Lookup Trajectory Point in the Robot Model*/
   std::unique_ptr<TrajectoryPoint> lookupTrajectoryPoint(const std::string & name,
                                                               double time) const;
 

--- a/moveit_simple/src/moveit_simple.cpp
+++ b/moveit_simple/src/moveit_simple.cpp
@@ -152,6 +152,7 @@ void Robot::addTrajPoint(const std::string & traj_name,
   traj_info_map_[traj_name].push_back({std::move(point), type, num_steps});
 }
 
+/*Lookup Trajectory Point in the Robot Model*/
 std::unique_ptr<TrajectoryPoint> Robot::lookupTrajectoryPoint(const std::string & name,
                                                             double time) const
 {
@@ -168,7 +169,7 @@ std::unique_ptr<TrajectoryPoint> Robot::lookupTrajectoryPoint(const std::string 
   else if (robot_model_ptr_->hasLinkModel(name) )
   {
     ROS_INFO_STREAM("Looked up named cart target from robot model: " << name);
-  virtual_robot_state_->update();  //Updating state for frame tansform below
+    virtual_robot_state_->update();  //Updating state for frame tansform below
     Eigen::Affine3d pose =  virtual_robot_state_->getFrameTransform(name);
     ROS_INFO_STREAM("Getting urdf/robot_state target: " << name << " frame: " << std::endl << pose.matrix());
     return std::unique_ptr<TrajectoryPoint>(new CartTrajectoryPoint(pose, time, name));
@@ -202,8 +203,6 @@ std::unique_ptr<TrajectoryPoint> Robot::lookupTrajectoryPoint(const std::string 
 }
 
 
-
-
 bool Robot::getJointSolution(const Eigen::Affine3d &pose, double timeout,
                              const std::vector<double> & seed,
                              std::vector<double> & joint_point) const
@@ -219,9 +218,70 @@ bool Robot::getJointSolution(const Eigen::Affine3d &pose, double timeout,
   return getIK(pose, local_seed, joint_point, timeout);
 }
 
+/*------------------------------------------------------------------------------------------------------------------------------*/
+
+/*ISSUE #20 -- getJointSolution() WITH CUSTOM TOOL FRAME FOR SOLVING IK*/
+bool Robot::getJointSolution(const Eigen::Affine3d &pose, const std::string& custom_tool_frame,
+                             double timeout, const std::vector<double> & seed,
+                             std::vector<double> & joint_point) const
+{
+
+  /*Transform Target/Goal Point from custom tool frame to moveit_end_link*/
+  const Eigen::Affine3d custom_frame_goal_pose = customToolFrameTF(pose, custom_tool_frame);
+
+  std::lock_guard<std::recursive_mutex> guard(m_);
+
+  std::vector<double> local_seed = seed;
+  if (seed.empty())
+  {
+    ROS_INFO_STREAM("Empty seed passed to getJointSolution, using current state");
+    local_seed =  getJointState();
+  }
+  return getIK(custom_frame_goal_pose, local_seed, joint_point, timeout);
+}
+
+/* Returns the goal pose transformed to moveit_end_link from Custom tool frame*/
+Eigen::Affine3d Robot::customToolFrameTF(const Eigen::Affine3d &target_pose,
+                                         const std::string& custom_tool_frame) const
+{
+  
+  if(custom_tool_frame.compare(robot_model_ptr_->getRootLinkName()) == 0) {
+      ROS_INFO_STREAM("Custom Tool Frame is same as moveit end_link");
+
+      return target_pose;
+    }
+
+  if (robot_model_ptr_->hasLinkModel(custom_tool_frame) ) {
+    
+    if( tf_buffer_.canTransform(robot_model_ptr_->getRootLinkName(), custom_tool_frame, ros::Time::now(), ros::Duration(0.1)) ) {
+      try
+      {
+          ROS_INFO_STREAM("Looked up tf named frame: " << custom_tool_frame);
+
+          geometry_msgs::TransformStamped trans_msg;
+          Eigen::Affine3d pose_buffer = target_pose;
+          trans_msg = tf_buffer_.lookupTransform(robot_model_ptr_->getRootLinkName(), 
+                               custom_tool_frame, ros::Time::now(), 
+                               ros::Duration(5.0));
+          
+          tf::transformMsgToEigen(trans_msg.transform, pose_buffer);
+          ROS_INFO_STREAM("Using TF to lookup transform " << custom_tool_frame << " frame: " << std::endl << pose_buffer.matrix());
+          
+          return pose_buffer;
+      }
+      catch (tf2::TransformException &ex)
+      {
+          ROS_ERROR_STREAM("TF transform lookup failed: " << ex.what());
+          throw ex;
+      }
+    }   
+  }
+}
+
+/*------------------------------------------------------------------------------------------------------------------------------*/
 
 bool Robot::getPose(const std::vector<double> & joint_point,
-                                  Eigen::Affine3d & pose) const
+                                   Eigen::Affine3d & pose) const
 {
   std::lock_guard<std::recursive_mutex> guard(m_);
 


### PR DESCRIPTION
TODO: Add Unit tests.

Added functionality for setting a goal_pose from a custom tool frame in getJointSolution(...). The function customToolFrameTF(...) takes a target_pose and a tool_frame as input arguments and computes the TF from this frame to the moveit_end_link. The transformed goal_pose is then used for calculating the IK. 

The next step would be to add this functionality to the isReachable(...) and isInCollision(...) methods.