### PR TITLE
Added Dependencies to prettyprint

### DIFF
--- a/moveit_simple/package.xml
+++ b/moveit_simple/package.xml
@@ -19,6 +19,7 @@
   <build_depend>moveit_core</build_depend>
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>moveit_visual_tools</build_depend>
+  <build_depend>prettyprint</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rosparam_handler</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -34,6 +35,7 @@
   <run_depend>geometry_msgs</run_depend>
   <run_depend>moveit_core</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
+  <run_depend>prettyprint</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rosparam_handler</run_depend>
   <run_depend>sensor_msgs</run_depend>


### PR DESCRIPTION
This fixes an issue that we caught when building a project with CI that had moveit_simple as a dependency. It started to build moveit_simple before prettyprint which caused this error:

```
Errors     << moveit_simple:cmake /root/catkin_ws/logs/moveit_simple/build.cmake.000.log
CMake Warning at /opt/ros/kinetic/share/catkin/cmake/catkinConfig.cmake:76 (find_package):

  Could not find a package configuration file provided by "prettyprint" with
  any of the following names:

    prettyprintConfig.cmake
    prettyprint-config.cmake
```

@shaun-edwards Please review.