### PR TITLE
Added isReachableStatic and isInCollisionStatic and transformToBaseStatic

### DIFF
--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -70,6 +70,31 @@ public:
   ~Robot();
 
   /**
+   * @brief isInCollision  returns true if pose results in robot config that is
+   * in collision with the environment as defined by the URDF.
+   * @param pose - cartesian pose of the tool to check
+   * @param frame - tool pose relative to frame
+   * @param joint_seed - named seed to use defined in srdf
+   * @param timeout - (optional) timeout for IK
+   * @return
+   */
+  bool isInCollision(const Eigen::Affine3d &pose, const std::string &frame,
+    const std::string &joint_seed, double timeout = 10.0) const;
+
+  /**
+   * @brief isInCollision  returns true if pose results in robot config that is
+   * in collision with the environment as defined by the URDF.
+   * @param pose - cartesian pose of the tool to check
+   * @param  frame_to_robot_base - transform from frame of pose to robot base frame
+   * @param joint_seed - named seed to use defined in srdf
+   * @param timeout - (optional) timeout for IK
+   * @return
+   */
+  bool isInCollision(const Eigen::Affine3d &pose, 
+    const geometry_msgs::TransformStamped &frame_to_robot_base,
+    const std::string &joint_seed, double timeout = 10.0) const;
+
+  /**
   * @brief isInCollision  returns true if joint_point results in robot config that is
   * in collision with the environment as defined by the URDF.
   * @param joint_point(optional) - joint position of the robot to check
@@ -87,20 +112,21 @@ public:
    * @param joint_seed (optional) - seed to use
    * @return
    */
-  bool isInCollision(const Eigen::Affine3d pose, const std::string &frame,
+  bool isInCollision(const Eigen::Affine3d &pose, const std::string &frame,
     double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>()) const;
 
   /**
    * @brief isInCollision  returns true if pose results in robot config that is
    * in collision with the environment as defined by the URDF.
    * @param pose - cartesian pose of the tool to check
-   * @param frame - tool pose relative to frame
-   * @param joint_seed - named seed to use defined in srdf
+   * @param frame_to_robot_base - transform from frame of pose to robot base frame
    * @param timeout - (optional) timeout for IK
+   * @param joint_seed (optional) - seed to use
    * @return
    */
-  bool isInCollision(const Eigen::Affine3d pose, const std::string &frame,
-    const std::string &joint_seed, double timeout = 10.0) const;
+  bool isInCollision(const Eigen::Affine3d &pose, 
+    const geometry_msgs::TransformStamped &frame_to_robot_base,
+    double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>()) const;
 
   /**
    * @brief isInCollision  returns true if pose results in robot config that is
@@ -133,9 +159,31 @@ public:
    * @param timeout - (optional) timeout for IK
    * @return
    */
-  bool isReachable(const std::string &name,
-      double timeout = 10.0,
-      std::vector<double> joint_seed = std::vector<double>()) const;
+  bool isReachable(const std::string &name, double timeout = 10.0,
+    std::vector<double> joint_seed = std::vector<double>()) const;
+
+  /**
+   * @brief isReachable - check if pose (relative to named frame) is reacheable.
+   * @param pose - pose to check
+   * @param frame - frame in which pose is expressed
+   * @param timeout - (optional) timeout for IK
+   * @param joint_seed - seed to use
+   * @return
+   */
+  bool isReachable(const Eigen::Affine3d &pose, const std::string &frame,
+    const std::string &joint_seed, double timeout = 10.0) const;
+
+  /**
+  * @brief isReachable - check if pose (relative to named frame) is reacheable.
+  * @param pose - pose to check
+  * @param frame_to_robot_base - transform from frame of pose to robot base frame
+  * @param timeout - (optional) timeout for IK
+  * @param joint_seed - seed to use
+  * @return
+  */
+  bool isReachable(const Eigen::Affine3d &pose, 
+    const geometry_msgs::TransformStamped &frame_to_robot_base,
+    const std::string &joint_seed, double timeout = 10.0) const;
 
   /**
    * @brief isReachable - check if pose (relative to named frame) is reacheable.
@@ -151,13 +199,14 @@ public:
   /**
    * @brief isReachable - check if pose (relative to named frame) is reacheable.
    * @param pose - pose to check
-   * @param frame - frame in which pose is expressed
+   * @param frame_to_robot_base - transform from frame of pose to robot base frame
    * @param timeout - (optional) timeout for IK
-   * @param joint_seed - seed to use
+   * @param joint_seed (optional) - named seed to use defined in srdf
    * @return
    */
-  bool isReachable(const Eigen::Affine3d &pose, const std::string &frame,
-    const std::string &joint_seed, double timeout = 10.0) const;
+  bool isReachable(const Eigen::Affine3d &pose, 
+    const geometry_msgs::TransformStamped &frame_to_robot_base,
+    double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>()) const;
 
   /**
    * @brief isReachable - check if pose (relative to named static frame) is reacheable.

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -136,6 +136,28 @@ public:
     const std::string &joint_seed, double timeout = 10.0) const;
 
   /**
+   * @brief isReachable - check if pose (relative to named static frame) is reacheable.
+   * @param pose - pose to check
+   * @param frame - frame in which pose is expressed
+   * @param timeout - (optional) timeout for IK
+   * @param joint_seed (optional) - named seed to use defined in srdf
+   * @return
+   */
+  bool isReachableStatic(const Eigen::Affine3d &pose, const std::string &frame,
+    double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>());
+
+  /**
+   * @brief isReachable - check if pose (relative to named static frame) is reacheable.
+   * @param pose - pose to check
+   * @param frame - frame in which pose is expressed
+   * @param timeout - (optional) timeout for IK
+   * @param joint_seed - seed to use
+   * @return
+   */
+  bool isReachableStatic(const Eigen::Affine3d &pose, const std::string &frame,
+    const std::string &joint_seed, double timeout = 10.0);
+
+  /**
    * @brief addTrajPoint - add point to trajectory.
    * @param traj_name - name of trajectory buffer to add point to
    * @param point_name - name of point to add
@@ -319,6 +341,8 @@ protected:
 
   Eigen::Affine3d transformToBase(const Eigen::Affine3d &in, const std::string &in_frame) const;
 
+  Eigen::Affine3d transformToBaseStatic(const Eigen::Affine3d &in, const std::string &in_frame);
+
   /**
    * @brief transformPoseBetweenFrames transforms frame_in to frame_out.
    * @param target_pose - goal pose for IK
@@ -473,6 +497,10 @@ protected:
   std::string ik_tip_frame_;
   Eigen::Affine3d ik_tip_to_srdf_tip_;
   Eigen::Affine3d srdf_base_to_ik_base_;
+
+  // transformToBaseStatic
+  Eigen::Affine3d transform_to_base_static_;
+  std::string transform_to_base_static_frame_;
 };
 } // namespace moveit_simple
 #endif // ROBOT_H

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -367,6 +367,9 @@ protected:
 
   Eigen::Affine3d transformToBase(const Eigen::Affine3d &in, const std::string &in_frame) const;
 
+  Eigen::Affine3d transformToBase(const Eigen::Affine3d &in, 
+    const geometry_msgs::TransformStamped &transform_msg) const;
+
   Eigen::Affine3d transformToBaseStatic(const Eigen::Affine3d &in, const std::string &in_frame);
 
   /**

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -129,30 +129,6 @@ public:
     double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>()) const;
 
   /**
-   * @brief isInCollision  returns true if pose results in robot config that is
-   * in collision with the environment as defined by the URDF.
-   * @param pose - cartesian pose of the tool to check
-   * @param frame - tool pose relative to static frame
-   * @param timeout - (optional) timeout for IK
-   * @param joint_seed (optional) - seed to use
-   * @return
-   */
-  bool isInCollisionStatic(const Eigen::Affine3d &pose, const std::string &frame,
-    double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>());
-
-  /**
-   * @brief isInCollision  returns true if pose results in robot config that is
-   * in collision with the environment as defined by the URDF.
-   * @param pose - cartesian pose of the tool to check
-   * @param frame - tool pose relative to static frame
-   * @param joint_seed - named seed to use defined in srdf
-   * @param timeout - (optional) timeout for IK
-   * @return
-   */
-  bool isInCollisionStatic(const Eigen::Affine3d &pose, const std::string &frame,
-    const std::string &joint_seed, double timeout = 10.0);
-
-  /**
    * @brief isReachable - check if point is reacheable.
    * @param name - name of point to check
    * @param joint_seed - (optional) tries to find joint solutions closest to seed
@@ -207,28 +183,6 @@ public:
   bool isReachable(const Eigen::Affine3d &pose, 
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>()) const;
-
-  /**
-   * @brief isReachable - check if pose (relative to named static frame) is reacheable.
-   * @param pose - pose to check
-   * @param frame - frame in which pose is expressed
-   * @param timeout - (optional) timeout for IK
-   * @param joint_seed (optional) - named seed to use defined in srdf
-   * @return
-   */
-  bool isReachableStatic(const Eigen::Affine3d &pose, const std::string &frame,
-    double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>());
-
-  /**
-   * @brief isReachable - check if pose (relative to named static frame) is reacheable.
-   * @param pose - pose to check
-   * @param frame - frame in which pose is expressed
-   * @param timeout - (optional) timeout for IK
-   * @param joint_seed - seed to use
-   * @return
-   */
-  bool isReachableStatic(const Eigen::Affine3d &pose, const std::string &frame,
-    const std::string &joint_seed, double timeout = 10.0);
 
   /**
    * @brief addTrajPoint - add point to trajectory.
@@ -419,8 +373,6 @@ protected:
   Eigen::Affine3d transformToBase(const Eigen::Affine3d &in, 
     const geometry_msgs::TransformStamped &transform_msg) const;
 
-  Eigen::Affine3d transformToBaseStatic(const Eigen::Affine3d &in, const std::string &in_frame);
-
   /**
    * @brief transformPoseBetweenFrames transforms frame_in to frame_out.
    * @param target_pose - goal pose for IK
@@ -575,10 +527,6 @@ protected:
   std::string ik_tip_frame_;
   Eigen::Affine3d ik_tip_to_srdf_tip_;
   Eigen::Affine3d srdf_base_to_ik_base_;
-
-  // transformToBaseStatic
-  geometry_msgs::TransformStamped transform_to_base_static_;
-  std::string transform_to_base_static_frame_;
 };
 } // namespace moveit_simple
 #endif // ROBOT_H

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -360,6 +360,8 @@ public:
    */
   double getSpeedModifier(void) const;
 
+  geometry_msgs::TransformStamped lookupTransformToBase(const std::string &in_frame) const;
+
 protected:
   Robot();
 

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -103,6 +103,30 @@ public:
     const std::string &joint_seed, double timeout = 10.0) const;
 
   /**
+   * @brief isInCollision  returns true if pose results in robot config that is
+   * in collision with the environment as defined by the URDF.
+   * @param pose - cartesian pose of the tool to check
+   * @param frame - tool pose relative to static frame
+   * @param timeout - (optional) timeout for IK
+   * @param joint_seed (optional) - seed to use
+   * @return
+   */
+  bool isInCollisionStatic(const Eigen::Affine3d &pose, const std::string &frame,
+    double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>());
+
+  /**
+   * @brief isInCollision  returns true if pose results in robot config that is
+   * in collision with the environment as defined by the URDF.
+   * @param pose - cartesian pose of the tool to check
+   * @param frame - tool pose relative to static frame
+   * @param joint_seed - named seed to use defined in srdf
+   * @param timeout - (optional) timeout for IK
+   * @return
+   */
+  bool isInCollisionStatic(const Eigen::Affine3d &pose, const std::string &frame,
+    const std::string &joint_seed, double timeout = 10.0);
+
+  /**
    * @brief isReachable - check if point is reacheable.
    * @param name - name of point to check
    * @param joint_seed - (optional) tries to find joint solutions closest to seed
@@ -499,7 +523,7 @@ protected:
   Eigen::Affine3d srdf_base_to_ik_base_;
 
   // transformToBaseStatic
-  Eigen::Affine3d transform_to_base_static_;
+  geometry_msgs::TransformStamped transform_to_base_static_;
   std::string transform_to_base_static_frame_;
 };
 } // namespace moveit_simple

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -363,6 +363,22 @@ public:
    */
   double getSpeedModifier(void) const;
 
+  void updateRvizRobotState(const Eigen::Affine3d &pose, const std::string &in_frame,
+    const std::string &joint_seed, double timeout = 10.0) const;
+
+  void updateRvizRobotState(const Eigen::Affine3d &pose, const std::string &in_frame,
+    std::vector<double> joint_seed = std::vector<double>(), double timeout = 10.0) const;
+
+  void updateRvizRobotState(const Eigen::Affine3d &pose, 
+    const geometry_msgs::TransformStamped &frame_to_robot_base,
+    const std::string &joint_seed, double timeout = 10.0) const;
+
+  void updateRvizRobotState(const Eigen::Affine3d &pose, 
+    const geometry_msgs::TransformStamped &frame_to_robot_base,
+    std::vector<double> joint_seed = std::vector<double>(),
+    double timeout = 10.0) const;
+
+
   geometry_msgs::TransformStamped lookupTransformToBase(const std::string &in_frame) const;
 
 protected:

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -1271,7 +1271,7 @@ bool Robot::getIK(const Eigen::Affine3d pose, std::vector<double> &joint_point,
     virtual_visual_tools_->deleteAllMarkers();
     virtual_visual_tools_->publishRobotState(virtual_robot_state_, rviz_visual_tools::PURPLE);
     virtual_visual_tools_->publishContactPoints(*virtual_robot_state_, &(*planning_scene_));
-    ros::spinOnce();
+    virtual_visual_tools_->trigger();
     return true;
   }
 

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -455,6 +455,47 @@ bool Robot::getPose(const std::vector<double> &joint_point, const std::string &t
   return get_pose;
 }
 
+bool Robot::isInCollision(const Eigen::Affine3d &pose, const std::string &frame,
+  const std::string &joint_seed, double timeout) const
+{
+  std::lock_guard<std::recursive_mutex> guard(m_);
+
+  std::map<std::string, double> m;
+  if (!joint_group_->getVariableDefaultPositions(joint_seed, m))
+  {
+    throw JointSeedException(joint_seed + " is not a named state defined in the SRDF / URDF");
+  }
+
+  std::vector<double> joints;
+  for (auto it = m.begin(); it != m.end(); ++it)
+  {
+    joints.push_back(it->second);
+  } 
+  
+  return this->isInCollision(pose, frame, timeout, joints); 
+}
+
+bool Robot::isInCollision(const Eigen::Affine3d &pose, 
+  const geometry_msgs::TransformStamped &frame_to_robot_base,
+  const std::string &joint_seed, double timeout) const
+{
+  std::lock_guard<std::recursive_mutex> guard(m_);
+
+  std::map<std::string, double> m;
+  if (!joint_group_->getVariableDefaultPositions(joint_seed, m))
+  {
+    throw JointSeedException(joint_seed + " is not a named state defined in the SRDF / URDF");
+  }
+
+  std::vector<double> joints;
+  for (auto it = m.begin(); it != m.end(); ++it)
+  {
+    joints.push_back(it->second);
+  }
+
+  return this->isInCollision(pose, frame_to_robot_base, timeout, joints);  
+}
+
 bool Robot::isInCollision(const std::vector<double> &joint_point) const
 {
   std::lock_guard<std::recursive_mutex> guard(m_);
@@ -473,7 +514,7 @@ bool Robot::isInCollision(const std::vector<double> &joint_point) const
   return inCollision;
 }
 
-bool Robot::isInCollision(const Eigen::Affine3d pose, const std::string &frame,
+bool Robot::isInCollision(const Eigen::Affine3d &pose, const std::string &frame,
   double timeout, std::vector<double> joint_seed) const
 {
   std::lock_guard<std::recursive_mutex> guard(m_);
@@ -481,11 +522,8 @@ bool Robot::isInCollision(const Eigen::Affine3d pose, const std::string &frame,
   bool inCollision = true;
   try
   {
-    Eigen::Affine3d pose_rel_robot = transformToBase(pose, frame);
-    std::unique_ptr<TrajectoryPoint> point =
-        std::unique_ptr<TrajectoryPoint>(new CartTrajectoryPoint(pose_rel_robot, 0.0));
-    virtual_robot_state_->copyJointGroupPositions(joint_group_->getName(), joint_seed);
-    inCollision = planning_scene_->isStateColliding(*virtual_robot_state_, joint_group_->getName());
+    auto pose_rel_robot = this->lookupTransformToBase(frame);
+    inCollision = isInCollision(pose, pose_rel_robot, timeout, joint_seed);
   }
   catch (tf2::TransformException &ex)
   {
@@ -496,22 +534,20 @@ bool Robot::isInCollision(const Eigen::Affine3d pose, const std::string &frame,
   return inCollision;
 }
 
-bool Robot::isInCollision(const Eigen::Affine3d pose, const std::string &frame,
-  const std::string &joint_seed, double timeout) const
+bool Robot::isInCollision(const Eigen::Affine3d &pose, 
+  const geometry_msgs::TransformStamped &frame_to_robot_base,
+  double timeout, std::vector<double> joint_seed) const
 {
-  std::map<std::string, double> m;
-  if (!joint_group_->getVariableDefaultPositions(joint_seed, m))
-  {
-    throw JointSeedException(joint_seed + " is not a named state defined in the SRDF / URDF");
-  }
+  std::lock_guard<std::recursive_mutex> guard(m_);
 
-  std::vector<double> joints;
-  for (auto it = m.begin(); it != m.end(); ++it)
-  {
-    joints.push_back(it->second);
-  }
+  bool in_collision = true;
 
-  return this->isInCollision(pose, frame, timeout, joints);
+  auto pose_rel_robot = this->transformToBase(pose, frame_to_robot_base);
+  std::unique_ptr<TrajectoryPoint> point = std::unique_ptr<TrajectoryPoint>(new CartTrajectoryPoint(pose_rel_robot, 0.0));
+  virtual_robot_state_->copyJointGroupPositions(joint_group_->getName(), joint_seed);
+  in_collision = planning_scene_->isStateColliding(*virtual_robot_state_, joint_group_->getName());
+
+  return in_collision;
 }
 
 bool Robot::isInCollisionStatic(const Eigen::Affine3d &pose, const std::string &frame,
@@ -574,58 +610,10 @@ bool Robot::isReachable(const std::string &name, double timeout,
 }
 
 bool Robot::isReachable(const Eigen::Affine3d &pose, const std::string &frame,
-  double timeout, std::vector<double> joint_seed) const
+  const std::string &joint_seed, double timeout) const
 {
   std::lock_guard<std::recursive_mutex> guard(m_);
 
-  bool reacheable = false;
-  try
-  {
-    Eigen::Affine3d pose_rel_robot = transformToBase(pose, frame);
-    std::unique_ptr<TrajectoryPoint> point =
-        std::unique_ptr<TrajectoryPoint>(new CartTrajectoryPoint(pose_rel_robot, 0.0));
-    reacheable = isReachable(point, timeout, joint_seed);
-  }
-  catch (tf2::TransformException &ex)
-  {
-    ROS_WARN_STREAM("Reacheability failed for arbitrary pose point: " << ex.what());
-    reacheable = false;
-  }
-
-  return reacheable;
-}
-
-bool Robot::isReachable(std::unique_ptr<TrajectoryPoint> &point, double timeout,
-  std::vector<double> joint_seed) const
-{
-  bool reacheable = false;
-
-  if (point)
-  {
-    if (joint_seed.empty())
-    {
-      ROS_DEBUG_STREAM("Empty seed passed to reach check, using current state");
-      virtual_robot_state_->copyJointGroupPositions(joint_group_->getName(), joint_seed);
-    }
-
-    std::unique_ptr<JointTrajectoryPoint> dummy = point->toJointTrajPoint(*this, timeout, joint_seed);
-    if (dummy)
-    {
-      reacheable = true;
-    }
-  }
-  else
-  {
-    ROS_ERROR_STREAM("Invalid point for reach check");
-    reacheable = false;
-  }
-
-  return reacheable;
-}
-
-bool Robot::isReachable(const Eigen::Affine3d &pose, const std::string &frame,
-  const std::string &joint_seed, double timeout) const
-{
   std::map<std::string, double> m;
   if (!joint_group_->getVariableDefaultPositions(joint_seed, m))
   {
@@ -639,6 +627,93 @@ bool Robot::isReachable(const Eigen::Affine3d &pose, const std::string &frame,
   }
 
   return this->isReachable(pose, frame, timeout, joints);
+}
+
+bool Robot::isReachable(const Eigen::Affine3d &pose,
+  const geometry_msgs::TransformStamped &frame_to_robot_base,
+  const std::string &joint_seed, double timeout) const
+{
+  std::lock_guard<std::recursive_mutex> guard(m_);
+  
+  std::map<std::string, double> m;
+  if (!joint_group_->getVariableDefaultPositions(joint_seed, m))
+  {
+    throw JointSeedException(joint_seed + " is not a named state defined in the SRDF / URDF");
+  }
+
+  std::vector<double> joints;
+  for (auto it = m.begin(); it != m.end(); ++it)
+  {
+    joints.push_back(it->second);
+  }
+
+  return this->isReachable(pose, frame_to_robot_base, timeout, joints);
+}
+
+bool Robot::isReachable(const Eigen::Affine3d &pose, const std::string &frame,
+  double timeout, std::vector<double> joint_seed) const
+{
+  std::lock_guard<std::recursive_mutex> guard(m_);
+
+  bool reachable = false;
+  try
+  {
+    auto frame_rel_robot = this->lookupTransformToBase(frame);
+    reachable = isReachable(pose, frame_rel_robot, timeout, joint_seed);
+
+    // Eigen::Affine3d pose_rel_robot = transformToBase(pose, frame);
+    // std::unique_ptr<TrajectoryPoint> point =
+    //     std::unique_ptr<TrajectoryPoint>(new CartTrajectoryPoint(pose_rel_robot, 0.0));
+    // reachable = isReachable(point, timeout, joint_seed);
+  }
+  catch (tf2::TransformException &ex)
+  {
+    ROS_WARN_STREAM("Reacheability failed for arbitrary pose point: " << ex.what());
+    reachable = false;
+  }
+
+  return reachable;
+}
+
+bool Robot::isReachable(const Eigen::Affine3d &pose,
+  const geometry_msgs::TransformStamped &frame_to_robot_base,
+  double timeout, std::vector<double> joint_seed) const
+{
+  std::lock_guard<std::recursive_mutex> guard(m_);
+
+  auto pose_rel_robot = this->transformToBase(pose, frame_to_robot_base);
+  std::unique_ptr<TrajectoryPoint> point = std::unique_ptr<TrajectoryPoint>(new CartTrajectoryPoint(pose_rel_robot, 0.0));
+  return this->isReachable(point, timeout, joint_seed);
+}
+
+bool Robot::isReachable(std::unique_ptr<TrajectoryPoint> &point, double timeout,
+  std::vector<double> joint_seed) const
+{
+  std::lock_guard<std::recursive_mutex> guard(m_);
+
+  bool reachable = false;
+
+  if (point)
+  {
+    if (joint_seed.empty())
+    {
+      ROS_DEBUG_STREAM("Empty seed passed to reach check, using current state");
+      virtual_robot_state_->copyJointGroupPositions(joint_group_->getName(), joint_seed);
+    }
+
+    std::unique_ptr<JointTrajectoryPoint> dummy = point->toJointTrajPoint(*this, timeout, joint_seed);
+    if (dummy)
+    {
+      reachable = true;
+    }
+  }
+  else
+  {
+    ROS_ERROR_STREAM("Invalid point for reach check");
+    reachable = false;
+  }
+
+  return reachable;
 }
 
 bool Robot::isReachableStatic(const Eigen::Affine3d &pose, const std::string &frame,

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -1213,13 +1213,11 @@ geometry_msgs::TransformStamped Robot::lookupTransformToBase(const std::string &
 
 Eigen::Affine3d Robot::transformToBase(const Eigen::Affine3d &in, const std::string &in_frame) const
 {
-  Eigen::Affine3d out;
+  geometry_msgs::TransformStamped frame_rel_robot_msg;
+
   try
   {
-    geometry_msgs::TransformStamped frame_rel_robot_msg = this->lookupTransformToBase(in_frame);
-    Eigen::Affine3d frame_rel_robot;
-    tf::transformMsgToEigen(frame_rel_robot_msg.transform, frame_rel_robot);
-    out = frame_rel_robot.inverse() * in;
+    frame_rel_robot_msg = this->lookupTransformToBase(in_frame);
   }
   catch (tf2::TransformException &ex)
   {
@@ -1227,6 +1225,19 @@ Eigen::Affine3d Robot::transformToBase(const Eigen::Affine3d &in, const std::str
       << "::" << ex.what());
     throw ex;
   }
+
+  return this->transformToBase(in, frame_rel_robot_msg);
+}
+
+Eigen::Affine3d Robot::transformToBase(const Eigen::Affine3d &in, 
+  const geometry_msgs::TransformStamped &transform_msg) const
+{
+  Eigen::Affine3d out;
+
+  Eigen::Affine3d frame_rel_robot;
+  tf::transformMsgToEigen(transform_msg.transform, frame_rel_robot);
+  out = frame_rel_robot.inverse() * in;
+
   return out;
 }
 
@@ -1254,9 +1265,7 @@ Eigen::Affine3d Robot::transformToBaseStatic(const Eigen::Affine3d &in, const st
     transform_to_base_static_ = frame_rel_robot_msg;
   }
 
-  Eigen::Affine3d frame_rel_robot;
-  tf::transformMsgToEigen(frame_rel_robot_msg.transform, frame_rel_robot);
-  return (frame_rel_robot.inverse() * in);  
+  return this->transformToBase(in, frame_rel_robot_msg);
 }
 
 bool Robot::getFK(const std::vector<double> &joint_point, Eigen::Affine3d &pose) const

--- a/moveit_simple/test/kuka_kr210.cpp
+++ b/moveit_simple/test/kuka_kr210.cpp
@@ -647,15 +647,18 @@ TEST_F(UserRobotTest, copy_current_pose)
   // Before the first execution robot should be at position "home"
   before_execution_1 = robot->getJointState();
   EXPECT_NO_THROW(robot->execute(TRAJECTORY_NAME));
+  ros::Duration(0.5).sleep();
 
   // Second Execution
   // Robot should be at "waypoint3" at all checkpoints from here on out.
   before_execution_2 = robot->getJointState();
   EXPECT_NO_THROW(robot->execute(TRAJECTORY_NAME));
+  ros::Duration(0.5).sleep();
 
   // Third Execution
   before_execution_3 = robot->getJointState();
   EXPECT_NO_THROW(robot->execute(TRAJECTORY_NAME));
+  ros::Duration(0.5).sleep();
 
   // Final Position
   final_position = robot->getJointState();


### PR DESCRIPTION
The original functions called transformToBase, which made a tf lookup for every single request causing lots of lag. These functions assume the transform to be static and will only look it up for the first instance.

@joshuaplusone please review.