### PR TITLE
Added prettyprint header to robot to fix build error

### DIFF
--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -25,9 +25,9 @@
 #include <ros/ros.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
-
 #include <moveit_simple/exceptions.h>
 #include <moveit_simple/point_types.h>
+#include <moveit_simple/prettyprint.hpp>
 #include <moveit_simple/robot.h>
 
 namespace moveit_simple

--- a/moveit_simple/test/kuka_kr210.cpp
+++ b/moveit_simple/test/kuka_kr210.cpp
@@ -20,6 +20,7 @@
 #include <eigen_conversions/eigen_msg.h>
 #include <gtest/gtest.h>
 #include <moveit_simple/moveit_simple.h>
+#include <moveit_simple/prettyprint.hpp>
 
 using testing::Types;
 

--- a/moveit_simple/test/motoman_mh5.cpp
+++ b/moveit_simple/test/motoman_mh5.cpp
@@ -20,6 +20,7 @@
 #include <eigen_conversions/eigen_msg.h>
 #include <gtest/gtest.h>
 #include <moveit_simple/moveit_simple.h>
+#include <moveit_simple/prettyprint.hpp>
 
 using testing::Types;
 


### PR DESCRIPTION
CI was failing with the latest ROS release. Build failed locally so I re-ran an old pipeline.

I guess they removed the << overload for vectors?

Here is error, it should be fixed now.

```
Errors     << moveit_simple:make /root/catkin_ws/logs/moveit_simple/build.make.000.log
In file included from /opt/ros/kinetic/include/ros/ros.h:40:0,
                 from /root/catkin_ws/src/moveit_simple/moveit_simple/src/robot.cpp:25:
/root/catkin_ws/src/moveit_simple/moveit_simple/src/robot.cpp: In constructor ‘moveit_simple::Robot::Robot(const ros::NodeHandle&, const string&, const string&)’:
/root/catkin_ws/src/moveit_simple/moveit_simple/src/robot.cpp:54:23: error: no match for ‘operator<<’ (operand types are ‘std::basic_ostream<char>’ and ‘const std::vector<std::__cxx11::basic_string<char> >’)
     << ", and tool: " << robot_model_ptr_->getLinkModelNames());
```

@joshuaplusone please review.