### PR TITLE
WIP: Add trajectory training service interface

### DIFF
--- a/moveit_simple/CMakeLists.txt
+++ b/moveit_simple/CMakeLists.txt
@@ -4,7 +4,6 @@ project(moveit_simple)
 add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
-  actionlib
   cmake_modules
   control_msgs
   dynamic_reconfigure
@@ -34,7 +33,6 @@ catkin_package(
   LIBRARIES
     ${PROJECT_NAME}
   CATKIN_DEPENDS
-    actionlib
     control_msgs
     dynamic_reconfigure
     eigen_conversions

--- a/moveit_simple/CMakeLists.txt
+++ b/moveit_simple/CMakeLists.txt
@@ -37,6 +37,7 @@ catkin_package(
     dynamic_reconfigure
     eigen_conversions
     geometry_msgs
+    moveit_simple_msgs
     roscpp
     rosparam_handler
     sensor_msgs

--- a/moveit_simple/CMakeLists.txt
+++ b/moveit_simple/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   moveit_core
   moveit_ros_planning
+  moveit_simple_msgs
   moveit_visual_tools
   roscpp
   rosparam_handler

--- a/moveit_simple/cfg/moveit_simple_dynamic_reconfigure_.params
+++ b/moveit_simple/cfg/moveit_simple_dynamic_reconfigure_.params
@@ -5,6 +5,6 @@ from rosparam_handler.parameter_generator_catkin import *
 gen = ParameterGenerator()
 
 gen.add("speed_modifier", paramtype="double", description="Speed Modifier for Execution", min=0.01, max=1.0, default=0.25, configurable=True)
-gen.add("joint_equality_tolerance", paramtype="double", description="Tolerance for equality between joint and cartesian representations of a point", min=0.0, max=1.0, default=0.005)
+gen.add("joint_equality_tolerance", paramtype="double", description="Tolerance for equality between joint and cartesian representations of a point", min=0.0, max=100.0, default=0.005, configurable=True)
 
 exit(gen.generate(PACKAGE, PACKAGE, "moveit_simple_dynamic_reconfigure_"))

--- a/moveit_simple/cfg/moveit_simple_dynamic_reconfigure_.params
+++ b/moveit_simple/cfg/moveit_simple_dynamic_reconfigure_.params
@@ -6,5 +6,6 @@ gen = ParameterGenerator()
 
 gen.add("speed_modifier", paramtype="double", description="Speed Modifier for Execution", min=0.01, max=1.0, default=0.25, configurable=True)
 gen.add("joint_equality_tolerance", paramtype="double", description="Tolerance for equality between joint and cartesian representations of a point", min=0.0, max=100.0, default=0.005, configurable=True)
+gen.add("action_client_timeout", paramtype="double", description="Time to wait before timing out on action calls", min=0.0, max=100.0, default=5.0, configurable=True)
 
 exit(gen.generate(PACKAGE, PACKAGE, "moveit_simple_dynamic_reconfigure_"))

--- a/moveit_simple/cfg/moveit_simple_dynamic_reconfigure_.params
+++ b/moveit_simple/cfg/moveit_simple_dynamic_reconfigure_.params
@@ -5,5 +5,6 @@ from rosparam_handler.parameter_generator_catkin import *
 gen = ParameterGenerator()
 
 gen.add("speed_modifier", paramtype="double", description="Speed Modifier for Execution", min=0.01, max=1.0, default=0.25, configurable=True)
+gen.add("joint_equality_tolerance", paramtype="double", description="Tolerance for equality between joint and cartesian representations of a point", min=0.0, max=1.0, default=0.005)
 
 exit(gen.generate(PACKAGE, PACKAGE, "moveit_simple_dynamic_reconfigure_"))

--- a/moveit_simple/include/moveit_simple/point_types.h
+++ b/moveit_simple/include/moveit_simple/point_types.h
@@ -175,8 +175,8 @@ public:
   }
 
   CombinedTrajectoryPoint(std::vector<double> &joint_point, const Eigen::Affine3d pose, double t, double tol,
-                          std::string name = std::string(), JointLockOptions options = JointLockOptions::LOCK_NONE,
-                          PointPreference type = PointPreference::JOINT, double timeout = 5.0)
+                          std::string name = std::string(), PointPreference type = PointPreference::JOINT,
+                          JointLockOptions options = JointLockOptions::LOCK_NONE, double timeout = 5.0)
     : TrajectoryPoint(name, t, (type == PointPreference::JOINT) ? PointType::JOINT : PointType::CARTESIAN, options)
     , options_(options)
     , joint_point_(joint_point)

--- a/moveit_simple/include/moveit_simple/point_types.h
+++ b/moveit_simple/include/moveit_simple/point_types.h
@@ -207,6 +207,8 @@ public:
     return timeout_;
   }
 
+  std::string pointVecToString(const std::vector<double> &vec) const;
+
 protected:
   
   virtual std::unique_ptr<JointTrajectoryPoint>

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -603,12 +603,15 @@ protected:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 
+  mutable ros::ServiceClient trajectory_training_client_;
+
   // ROS objects
   ros::NodeHandle nh_;
   mutable std::recursive_mutex m_;
 
   // Dynamic Reconfigure
   double speed_modifier_;
+  double joint_equality_tolerance_;
   moveit_simple_dynamic_reconfigure_Parameters params_;
   dynamic_reconfigure::Server<moveit_simple_dynamic_reconfigure_Config> dynamic_reconfig_server_;
 

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -34,6 +34,8 @@
 
 #include <moveit_simple/moveit_simple_dynamic_reconfigure_Parameters.h>
 #include <moveit_simple/point_types.h>
+#include <actionlib/client/simple_action_client.h>
+#include "moveit_simple_msgs/LookupWaypointAction.h"
 
 namespace moveit_simple
 {
@@ -603,7 +605,8 @@ protected:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 
-  mutable ros::ServiceClient trajectory_training_client_;
+  // Action Server to Lookup Waypoints
+  mutable actionlib::SimpleActionClient<moveit_simple_msgs::LookupWaypointAction> lookup_wp_ac_;
 
   // ROS objects
   ros::NodeHandle nh_;
@@ -612,6 +615,7 @@ protected:
   // Dynamic Reconfigure
   double speed_modifier_;
   double joint_equality_tolerance_;
+  double action_client_timeout_;
   moveit_simple_dynamic_reconfigure_Parameters params_;
   std::shared_ptr<dynamic_reconfigure::Server<moveit_simple_dynamic_reconfigure_Config>> dynamic_reconfig_server_;
 

--- a/moveit_simple/package.xml
+++ b/moveit_simple/package.xml
@@ -12,7 +12,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>actionlib</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>control_msgs</build_depend>
@@ -31,7 +30,6 @@
   <build_depend>trajectory_msgs</build_depend>
   <build_depend>moveit_simple_msgs</build_depend>
 
-  <run_depend>actionlib</run_depend>
   <run_depend>control_msgs</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>eigen</run_depend>

--- a/moveit_simple/package.xml
+++ b/moveit_simple/package.xml
@@ -29,6 +29,7 @@
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>trajectory_msgs</build_depend>
+  <build_depend>moveit_simple_msgs</build_depend>
 
   <run_depend>actionlib</run_depend>
   <run_depend>control_msgs</run_depend>
@@ -49,6 +50,7 @@
   <run_depend>tf2_geometry_msgs</run_depend>
   <run_depend>tf2_ros</run_depend>
   <run_depend>trajectory_msgs</run_depend>
+  <run_depend>moveit_simple_msgs</run_depend>
 
   <test_depend>moveit_kinematics</test_depend>
   <test_depend>rostest</test_depend>

--- a/moveit_simple/src/point_types.cpp
+++ b/moveit_simple/src/point_types.cpp
@@ -123,6 +123,15 @@ std::unique_ptr<CartTrajectoryPoint> CombinedTrajectoryPoint::toCartTrajPoint(co
   }
 }
 
+std::string CombinedTrajectoryPoint::pointVecToString(const std::vector<double> &vec) const
+{
+  std::stringstream ss;
+  ss << "[ ";
+  for_each(vec.begin(), vec.end(), [&ss](const double &point){ss << point << " ";});
+  ss << " ]";
+  return ss.str();
+}
+
 bool CombinedTrajectoryPoint::compareJointAndCart(const Robot &robot, double timeout) const
 {
   std::vector<double> cart_point;
@@ -141,7 +150,12 @@ bool CombinedTrajectoryPoint::compareJointAndCart(const Robot &robot, double tim
     }
     if (!in_tol)
     {
-      ROS_WARN_STREAM("CombinedTrajectoryPoint: Cartesian and Joint representations are out of tolerance");
+      std::stringstream ss;
+      ss << "CombinedTrajectoryPoint: Cartesian and Joint representations are out of tolerance. ";
+      ss << ("Using %s representation, per preference.", this->type() == PointType::JOINT ? "joint" : "cartesian") << std::endl;
+      ss << "Joint Representation Joints: " << pointVecToString(joint_point_) << std::endl;
+      ss << "Cartesian Representation Joints: " << pointVecToString(cart_point) << std::endl;
+      ROS_WARN_STREAM(ss.str());
     }
   }
   else

--- a/moveit_simple/src/point_types.cpp
+++ b/moveit_simple/src/point_types.cpp
@@ -25,7 +25,6 @@
 
 namespace moveit_simple
 {
-
 void TrajectoryPoint::setJointLockOptions(const JointLockOptions &options)
 {
   joint_lock_options_ = options;
@@ -36,8 +35,9 @@ JointLockOptions TrajectoryPoint::getJointLockOptions()
   return joint_lock_options_;
 }
 
-std::unique_ptr<JointTrajectoryPoint> JointTrajectoryPoint::toJointTrajPoint(
-  const Robot &robot, double timeout, const std::vector<double> &seed, JointLockOptions options) const
+std::unique_ptr<JointTrajectoryPoint> JointTrajectoryPoint::toJointTrajPoint(const Robot &robot, double timeout,
+                                                                             const std::vector<double> &seed,
+                                                                             JointLockOptions options) const
 {
   ROS_DEBUG_STREAM("JointTrajectoryPoint: passing through joint trajectory point");
   return std::unique_ptr<JointTrajectoryPoint>(new JointTrajectoryPoint(*this));
@@ -59,8 +59,9 @@ std::unique_ptr<CartTrajectoryPoint> JointTrajectoryPoint::toCartTrajPoint(const
   }
 }
 
-std::unique_ptr<JointTrajectoryPoint> CartTrajectoryPoint::toJointTrajPoint(
-  const Robot &robot, double timeout, const std::vector<double> &seed, JointLockOptions options) const
+std::unique_ptr<JointTrajectoryPoint> CartTrajectoryPoint::toJointTrajPoint(const Robot &robot, double timeout,
+                                                                            const std::vector<double> &seed,
+                                                                            JointLockOptions options) const
 {
   std::vector<double> joints;
 
@@ -82,36 +83,63 @@ std::unique_ptr<CartTrajectoryPoint> CartTrajectoryPoint::toCartTrajPoint(const 
   return std::unique_ptr<CartTrajectoryPoint>(new CartTrajectoryPoint(*this));
 }
 
-std::unique_ptr<JointTrajectoryPoint> CombinedTrajectoryPoint::toJointTrajPoint(
-  const Robot &robot, double timeout, const std::vector<double> &seed, JointLockOptions options) const
+std::unique_ptr<JointTrajectoryPoint> CombinedTrajectoryPoint::toJointTrajPoint(const Robot &robot, double timeout,
+                                                                                const std::vector<double> &seed,
+                                                                                JointLockOptions options) const
 {
   std::vector<double> joints;
   std::copy(joint_point_.begin(), joint_point_.end(), std::back_inserter(joints));
-  return std::unique_ptr<JointTrajectoryPoint>(new JointTrajectoryPoint(joints, time(), name(), options));
+  if (compareJointAndCart(robot, timeout))
+  {
+    return std::unique_ptr<JointTrajectoryPoint>(new JointTrajectoryPoint(joints, time(), name(), options));
+  }
+  else if(this->type() == PointType::JOINT)
+  {
+    return std::unique_ptr<JointTrajectoryPoint>(new JointTrajectoryPoint(joints, time(), name(), options));
+  }
+  else
+  {
+    auto point = std::unique_ptr<CartTrajectoryPoint>(new CartTrajectoryPoint(pose(), time(), name(), jointLockOptions()));
+    return point->toJointTrajPoint(robot, timeout, joints, options);
+  }
 }
 
 std::unique_ptr<CartTrajectoryPoint> CombinedTrajectoryPoint::toCartTrajPoint(const Robot &robot) const
 {
-  return std::unique_ptr<CartTrajectoryPoint>(new CartTrajectoryPoint(pose(), time(), name(), jointLockOptions()));
+  if(compareJointAndCart(robot, this->timeout()))
+  {
+    return std::unique_ptr<CartTrajectoryPoint>(new CartTrajectoryPoint(pose(), time(), name(), jointLockOptions()));
+  }
+  else if(this->type() == PointType::JOINT)
+  {
+    std::vector<double> joints;
+    std::copy(joint_point_.begin(), joint_point_.end(), std::back_inserter(joints));
+    auto point = std::unique_ptr<JointTrajectoryPoint>(new JointTrajectoryPoint(joints, time(), name(), jointLockOptions()));
+    return point->toCartTrajPoint(robot);
+  }
+  else
+  {
+    return std::unique_ptr<CartTrajectoryPoint>(new CartTrajectoryPoint(pose(), time(), name(), jointLockOptions()));
+  }
 }
 
-bool CombinedTrajectoryPoint::compareJointAndCart(const Robot &robot, double timeout, double tolerance)
+bool CombinedTrajectoryPoint::compareJointAndCart(const Robot &robot, double timeout) const
 {
   std::vector<double> cart_point;
   bool in_tol;
 
-  if(robot.getJointSolution(pose_, timeout, joint_point_, cart_point))
+  if (robot.getJointSolution(pose_, timeout, joint_point_, cart_point))
   {
     std::vector<double>::const_iterator joint_it = joint_point_.begin();
     std::vector<double>::const_iterator cart_it = cart_point.begin();
 
-    while(in_tol && joint_it != joint_point_.end())
+    while (in_tol && joint_it != joint_point_.end())
     {
-      in_tol = std::abs(*joint_it - *cart_it) <= tolerance;
+      in_tol = std::abs(*joint_it - *cart_it) <= tol_;
       joint_it++;
       cart_it++;
     }
-    if(!in_tol)
+    if (!in_tol)
     {
       ROS_WARN_STREAM("CombinedTrajectoryPoint: Cartesian and Joint representations are out of tolerance");
     }
@@ -125,4 +153,4 @@ bool CombinedTrajectoryPoint::compareJointAndCart(const Robot &robot, double tim
   return in_tol;
 }
 
-} // namespace moveit_simple
+}  // namespace moveit_simple

--- a/moveit_simple/src/point_types.cpp
+++ b/moveit_simple/src/point_types.cpp
@@ -151,7 +151,7 @@ bool CombinedTrajectoryPoint::compareJointAndCart(const Robot &robot, double tim
     if (!in_tol)
     {
       std::stringstream ss;
-      ss << "CombinedTrajectoryPoint: Cartesian and Joint representations are out of tolerance. ";
+      ss << "CombinedTrajectoryPoint: Cartesian and Joint representations are out of tolerance. " << std::endl;
       ss << "Using " << ((this->type() == PointType::JOINT) ? "joint" : "cartesian") << " representation, per preference." << std::endl;
       ss << "Joint Representation Joints: " << pointVecToString(joint_point_) << std::endl;
       ss << "Cartesian Representation Joints: " << pointVecToString(cart_point) << std::endl;

--- a/moveit_simple/src/point_types.cpp
+++ b/moveit_simple/src/point_types.cpp
@@ -152,7 +152,7 @@ bool CombinedTrajectoryPoint::compareJointAndCart(const Robot &robot, double tim
     {
       std::stringstream ss;
       ss << "CombinedTrajectoryPoint: Cartesian and Joint representations are out of tolerance. ";
-      ss << ("Using %s representation, per preference.", this->type() == PointType::JOINT ? "joint" : "cartesian") << std::endl;
+      ss << "Using " << ((this->type() == PointType::JOINT) ? "joint" : "cartesian") << " representation, per preference." << std::endl;
       ss << "Joint Representation Joints: " << pointVecToString(joint_point_) << std::endl;
       ss << "Cartesian Representation Joints: " << pointVecToString(cart_point) << std::endl;
       ROS_WARN_STREAM(ss.str());

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -381,6 +381,8 @@ std::unique_ptr<TrajectoryPoint> Robot::lookupTrajectoryPoint(const std::string&
   }
   else
   {
+    ROS_INFO_STREAM("Requesting trajectory training service info for waypoint: " << name);
+
     std::vector<std::string> waypoint_names;
     waypoint_names.push_back(name);
 

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -399,7 +399,8 @@ std::unique_ptr<TrajectoryPoint> Robot::lookupTrajectoryPoint(const std::string&
       tf::transformMsgToEigen(waypoint.transform_stamped.transform, pose);
 
       return std::unique_ptr<TrajectoryPoint>(
-          new CombinedTrajectoryPoint(waypoint.joint_point, pose, time, joint_equality_tolerance_, name));
+          new CombinedTrajectoryPoint(waypoint.joint_point, pose, time, joint_equality_tolerance_, name,
+                                      CombinedTrajectoryPoint::PointPreference::CARTESIAN));
     }
     else
     {

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -391,14 +391,13 @@ std::unique_ptr<TrajectoryPoint> Robot::lookupTrajectoryPoint(const std::string&
 
     if (trajectory_training_client_.call(srv) && srv.response.result && srv.response.waypoints.size() > 0)
     {
-      moveit_simple_msgs::CombinedJointPoint cjp;
-      cjp = srv.response.waypoints.front();
+      auto waypoint = srv.response.waypoints.front();
 
       Eigen::Affine3d pose;
-      tf::transformMsgToEigen(cjp.transform_stamped.transform, pose);
+      tf::transformMsgToEigen(waypoint.transform_stamped.transform, pose);
 
       return std::unique_ptr<TrajectoryPoint>(
-          new CombinedTrajectoryPoint(cjp.joint_point, pose, time, joint_equality_tolerance_, name));
+          new CombinedTrajectoryPoint(waypoint.joint_point, pose, time, joint_equality_tolerance_, name));
     }
     else
     {

--- a/moveit_simple_msgs/CMakeLists.txt
+++ b/moveit_simple_msgs/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(moveit_simple_msgs)
+
+add_compile_options(-std=c++11)
+
+find_package(catkin REQUIRED COMPONENTS
+  message_generation
+  message_runtime
+  roscpp
+  sensor_msgs
+  std_msgs
+  tf2
+  tf2_geometry_msgs
+  tf2_ros
+)
+
+add_service_files(
+  FILES
+  TrajectoryTrainer.srv
+)
+
+add_message_files(
+  FILES
+  CombinedJointPoint.msg
+)
+
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+  geometry_msgs
+)
+
+catkin_package(
+  CATKIN_DEPENDS roscpp sensor_msgs std_msgs tf2 tf2_geometry_msgs tf2_ros
+)
+
+###########
+## Build ##
+###########
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+

--- a/moveit_simple_msgs/CMakeLists.txt
+++ b/moveit_simple_msgs/CMakeLists.txt
@@ -5,7 +5,6 @@ add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
   message_generation
-  message_runtime
   roscpp
   sensor_msgs
   std_msgs
@@ -14,14 +13,14 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_ros
 )
 
-add_service_files(
-  FILES
-  TrajectoryTrainer.srv
-)
-
 add_message_files(
   FILES
   CombinedJointPoint.msg
+)
+
+add_service_files(
+  FILES
+  TrajectoryTrainer.srv
 )
 
 generate_messages(
@@ -31,14 +30,15 @@ generate_messages(
 )
 
 catkin_package(
-  CATKIN_DEPENDS roscpp sensor_msgs std_msgs tf2 tf2_geometry_msgs tf2_ros
-)
-
-###########
-## Build ##
-###########
-
-include_directories(
-  ${catkin_INCLUDE_DIRS}
+  INCLUDE_DIRS
+  LIBRARIES
+  CATKIN_DEPENDS
+    message_runtime
+    roscpp
+    sensor_msgs
+    std_msgs
+    tf2
+    tf2_geometry_msgs
+    tf2_ros
 )
 

--- a/moveit_simple_msgs/CMakeLists.txt
+++ b/moveit_simple_msgs/CMakeLists.txt
@@ -4,6 +4,7 @@ project(moveit_simple_msgs)
 add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
+  actionlib_msgs
   message_generation
   roscpp
   sensor_msgs
@@ -13,26 +14,36 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_ros
 )
 
+add_action_files(
+  DIRECTORY action
+  FILES
+    LookupTrajectory.action
+    LookupWaypoint.action
+)
+
 add_message_files(
   FILES
-  CombinedJointPoint.msg
+    CombinedJointPoint.msg
 )
 
 add_service_files(
   FILES
-  TrajectoryTrainer.srv
+    LookupTrajectory.srv
+    LookupWaypoint.srv
 )
 
 generate_messages(
   DEPENDENCIES
-  std_msgs
-  geometry_msgs
+    actionlib_msgs
+    std_msgs
+    geometry_msgs
 )
 
 catkin_package(
   INCLUDE_DIRS
   LIBRARIES
   CATKIN_DEPENDS
+    actionlib_msgs
     message_runtime
     roscpp
     sensor_msgs

--- a/moveit_simple_msgs/action/LookupTrajectory.action
+++ b/moveit_simple_msgs/action/LookupTrajectory.action
@@ -1,0 +1,8 @@
+# Get Trajectory Action
+string trajectory_name
+---
+bool success
+CombinedJointPoint[] waypoints
+---
+bool trajectory_exists
+bool waypoints_exist

--- a/moveit_simple_msgs/action/LookupWaypoint.action
+++ b/moveit_simple_msgs/action/LookupWaypoint.action
@@ -1,0 +1,7 @@
+# Get Waypoint Action
+string waypoint_name
+---
+bool success
+CombinedJointPoint waypoint
+---
+# no feedback

--- a/moveit_simple_msgs/msg/CombinedJointPoint.msg
+++ b/moveit_simple_msgs/msg/CombinedJointPoint.msg
@@ -1,0 +1,5 @@
+# Combined Joint Point Message
+string waypoint_name
+string[] joint_names
+float64[] joint_point
+geometry_msgs/TransformStamped transform_stamped

--- a/moveit_simple_msgs/package.xml
+++ b/moveit_simple_msgs/package.xml
@@ -32,6 +32,8 @@
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
+  <depend>actionlib</depend>
+  <depend>actionlib_msgs</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/moveit_simple_msgs/package.xml
+++ b/moveit_simple_msgs/package.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>moveit_simple_msgs</name>
+  <version>0.0.0</version>
+  <description>The moveit_simple_msgs package</description>
+
+  <maintainer email="aaronwood@plusonerobotics.com">Aaron Wood</maintainer>
+
+  <license>Apache 2.0</license> <!-- moveit_simple_msgs --> 
+  <license>Boost Software License</license> <!-- prettyprint -->
+
+  <author email="aaronwood@plusonerobotics.com">Aaron Wood</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>tf2</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>tf2_ros</build_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>sensor_msgs</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>tf2</build_export_depend>
+  <build_export_depend>tf2_geometry_msgs</build_export_depend>
+  <build_export_depend>tf2_ros</build_export_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>tf2</exec_depend>
+  <exec_depend>tf2_geometry_msgs</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/moveit_simple_msgs/srv/LookupTrajectory.srv
+++ b/moveit_simple_msgs/srv/LookupTrajectory.srv
@@ -1,0 +1,6 @@
+# Trajectory Lookup
+# Requests all waypoints associated with a trajectory name
+
+string trajectory_name
+---
+CombinedJointPoint[] waypoints

--- a/moveit_simple_msgs/srv/LookupWaypoint.srv
+++ b/moveit_simple_msgs/srv/LookupWaypoint.srv
@@ -1,0 +1,6 @@
+# Waypoint Lookup
+
+string waypoint_name         # Name of waypoints to look up
+---
+bool result                  # True if waypoint found, False otherwise
+CombinedJointPoint waypoint  # Requested waypoint

--- a/moveit_simple_msgs/srv/TrajectoryTrainer.srv
+++ b/moveit_simple_msgs/srv/TrajectoryTrainer.srv
@@ -1,0 +1,17 @@
+uint8 NEW_WP=0				# Create a new waypoint at current location 			[required: waypoint name, optional: trajectory name]
+uint8 DEL_WP=1				# Delete existing waypoint(s) from config 				[required: waypoint name(s)]
+uint8 GET_WP=2				# Request information on existing waypoint(s) 			[required: waypoint name(s)]
+uint8 UPDATE_WP=3			# Replace previous waypoint data with current location 	[required: waypoint name]	
+uint8 APPEND_WP_TO_TRAJ=4	# Add waypoint(s) to trajectory                         [required: trajectory name, waypoint name(s)] 
+uint8 REMOVE_WP_FROM_TRAJ=5 # Remove waypoint(s) from trajectory if it(they) exist 	[required: trajectory name, waypoint name(s)]
+uint8 NEW_TRAJ=10			# Create a new trajectory, optionally populate          [required: trajectory name, optional: waypoint name(s)]
+uint8 DEL_TRAJ=11			# Delete a trajectory from config						[required: trajectory name]
+uint8 GET_TRAJ=12			# Get all waypoints in a trajectory 					[required: trajectory name]
+
+uint8 op_type
+string trajectory_name
+string[] waypoint_names
+---
+bool result
+string message
+CombinedJointPoint[] waypoints

--- a/moveit_simple_msgs/srv/TrajectoryTrainer.srv
+++ b/moveit_simple_msgs/srv/TrajectoryTrainer.srv
@@ -7,6 +7,8 @@ uint8 REMOVE_WP_FROM_TRAJ=5 # Remove waypoint(s) from trajectory if it(they) exi
 uint8 NEW_TRAJ=10			# Create a new trajectory, optionally populate          [required: trajectory name, optional: waypoint name(s)]
 uint8 DEL_TRAJ=11			# Delete a trajectory from config						[required: trajectory name]
 uint8 GET_TRAJ=12			# Get all waypoints in a trajectory 					[required: trajectory name]
+uint8 CLEAR_TRAJ=13			# Clears the contents of a trajectory 					[required: trajectory name]
+uint8 RELOAD_YAML=255		# Update internal storage to match YAML                 [required: N/A]
 
 uint8 op_type
 string trajectory_name


### PR DESCRIPTION
@shaun-edwards please review. WIP pending functional testing.

Extends lookupTrajectoryPoint to also check for point info from a **TrajectoryTrainer** service, and adds a new TrajectoryPoint type **CombinedTrajectoryPoint**.

Trainer service definition and CombinedJointPoint message types are defined in new moveit_simple_msgs package.