### PR TITLE
remove trailing whitespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-sudo: required 
-dist: trusty 
-language: generic 
+sudo: required
+dist: trusty
+language: generic
 compiler:
   - gcc
 notifications:
@@ -13,5 +13,5 @@ env:
     - ROS_DISTRO="kinetic" UPSTREAM_WORKSPACE=file  ROSINSTALL_FILENAME=.travis.rosinstall
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
-script: 
+script:
   - source .ci_config/travis.sh

--- a/moveit_simple/CMakeLists.txt
+++ b/moveit_simple/CMakeLists.txt
@@ -57,7 +57,7 @@ include_directories(
   ${EIGEN3_INCLUDE_DIRS}
 )
 
-add_library(${PROJECT_NAME} 
+add_library(${PROJECT_NAME}
   src/joint_lock_options.cpp
   src/joint_locker.cpp
   src/online_robot.cpp

--- a/moveit_simple/include/moveit_simple/exceptions.h
+++ b/moveit_simple/include/moveit_simple/exceptions.h
@@ -50,12 +50,12 @@ public:
 class IKFailException : public std::runtime_error
 {
 public:
-  IKFailException(const std::string errorDescription) 
+  IKFailException(const std::string errorDescription)
     : std::runtime_error(errorDescription) { }
 };
 
 /**
- * @brief IKSolverTransformException: 
+ * @brief IKSolverTransformException:
  *
  * This inherits from std::runtime_error.
  * This is an exception class to be thrown when a custom iksolver is
@@ -78,12 +78,12 @@ public:
 class CollisionDetected : public std::runtime_error
 {
 public:
-  CollisionDetected(const std::string errorDescription) 
+  CollisionDetected(const std::string errorDescription)
     : std::runtime_error(errorDescription) { }
 };
 
 /**
- * @brief JointSeedException: 
+ * @brief JointSeedException:
  *
  * This inherits from std::runtime_error.
  * This is an exception class to be thrown when a pre-defined joint
@@ -93,7 +93,7 @@ public:
 class JointSeedException : public std::runtime_error
 {
 public:
-  JointSeedException(const std::string error_description) 
+  JointSeedException(const std::string error_description)
     : std::runtime_error(error_description) { }
 };
 } // namespace moveit_simple

--- a/moveit_simple/include/moveit_simple/online_robot.h
+++ b/moveit_simple/include/moveit_simple/online_robot.h
@@ -40,7 +40,7 @@ class OnlineRobot : public Robot
 public:
   /**
   * @brief Constructor
-  */  
+  */
   OnlineRobot(const ros::NodeHandle &nh, const std::string &robot_description,
     const std::string &group_name);
 
@@ -51,7 +51,7 @@ public:
   * some tcp frame.
   */
   OnlineRobot(const ros::NodeHandle &nh, const std::string &robot_description,
-    const std::string &group_name, const std::string &ik_base_frame, 
+    const std::string &group_name, const std::string &ik_base_frame,
     const std::string &ik_tip_frame);
 
   /**

--- a/moveit_simple/include/moveit_simple/point_types.h
+++ b/moveit_simple/include/moveit_simple/point_types.h
@@ -58,7 +58,7 @@ typedef std::vector<TrajectoryPointInfo> TrajectoryInfo;
 
 class TrajectoryPoint
 {
-public: 
+public:
   friend class Robot;
 
   virtual ~TrajectoryPoint() { }
@@ -112,7 +112,7 @@ class JointTrajectoryPoint : public TrajectoryPoint
 public:
   friend class CombinedTrajectoryPoint;
   JointTrajectoryPoint() : TrajectoryPoint("", 0.0, PointType::JOINT) { }
-  
+
   virtual ~JointTrajectoryPoint() { }
 
   JointTrajectoryPoint(std::vector<double> &joint_point, double t, std::string name = std::string(),
@@ -196,7 +196,7 @@ public:
   {
     return pose_;
   }
-  
+
   const std::vector<double> &jointPoint() const
   {
     return joint_point_;
@@ -210,7 +210,7 @@ public:
   std::string pointVecToString(const std::vector<double> &vec) const;
 
 protected:
-  
+
   virtual std::unique_ptr<JointTrajectoryPoint>
   toJointTrajPoint(const Robot &robot, double timeout, const std::vector<double> &seed,
                    JointLockOptions options = JointLockOptions::LOCK_NONE) const;

--- a/moveit_simple/include/moveit_simple/prettyprint.hpp
+++ b/moveit_simple/include/moveit_simple/prettyprint.hpp
@@ -89,7 +89,7 @@ namespace pretty_print
     struct delimiters
     {
         using type = delimiters_values<TChar>;
-        static const type values; 
+        static const type values;
     };
 
 

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -50,7 +50,7 @@ class Robot
 public:
   /**
   * @brief Constructor
-  */  
+  */
   Robot(const ros::NodeHandle &nh, const std::string &robot_description,
     const std::string &group_name);
 
@@ -92,7 +92,7 @@ public:
    * @param timeout - (optional) timeout for IK
    * @return
    */
-  bool isInCollision(const Eigen::Affine3d &pose, 
+  bool isInCollision(const Eigen::Affine3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     const std::string &joint_seed, double timeout = 10.0) const;
 
@@ -141,7 +141,7 @@ public:
    * @param joint_seed (optional) - seed to use
    * @return
    */
-  bool isInCollision(const Eigen::Affine3d &pose, 
+  bool isInCollision(const Eigen::Affine3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>()) const;
 
@@ -174,7 +174,7 @@ public:
   * @param joint_seed - seed to use
   * @return
   */
-  bool isReachable(const Eigen::Affine3d &pose, 
+  bool isReachable(const Eigen::Affine3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     const std::string &joint_seed, double timeout = 10.0) const;
 
@@ -212,7 +212,7 @@ public:
    * @param joint_seed (optional) - named seed to use defined in srdf
    * @return
    */
-  bool isReachable(const Eigen::Affine3d &pose, 
+  bool isReachable(const Eigen::Affine3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     double timeout = 10.0, std::vector<double> joint_seed = std::vector<double>()) const;
 
@@ -439,11 +439,11 @@ public:
   void updateRvizRobotState(const Eigen::Affine3d &pose, const std::string &in_frame,
     std::vector<double> joint_seed = std::vector<double>(), double timeout = 10.0) const;
 
-  void updateRvizRobotState(const Eigen::Affine3d &pose, 
+  void updateRvizRobotState(const Eigen::Affine3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     const std::string &joint_seed, double timeout = 10.0) const;
 
-  void updateRvizRobotState(const Eigen::Affine3d &pose, 
+  void updateRvizRobotState(const Eigen::Affine3d &pose,
     const geometry_msgs::TransformStamped &frame_to_robot_base,
     std::vector<double> joint_seed = std::vector<double>(),
     double timeout = 10.0) const;
@@ -460,7 +460,7 @@ protected:
 
   Eigen::Affine3d transformToBase(const Eigen::Affine3d &in, const std::string &in_frame) const;
 
-  Eigen::Affine3d transformToBase(const Eigen::Affine3d &in, 
+  Eigen::Affine3d transformToBase(const Eigen::Affine3d &in,
     const geometry_msgs::TransformStamped &transform_msg) const;
 
   /**
@@ -522,7 +522,7 @@ protected:
    * @param t: parameteric time
    * @param point: interpolated Cartesian point
    */
-  void interpolate(const std::unique_ptr<CartTrajectoryPoint> &from, 
+  void interpolate(const std::unique_ptr<CartTrajectoryPoint> &from,
     const std::unique_ptr<CartTrajectoryPoint> &to, double t,
     std::unique_ptr<CartTrajectoryPoint> &point) const;
 

--- a/moveit_simple/package.xml
+++ b/moveit_simple/package.xml
@@ -3,10 +3,10 @@
   <name>moveit_simple</name>
   <version>0.1.0</version>
   <description>Includes simple wrappers for calling MoveIt as a ROS based library.  Similar function as MoveGroup but all calls are made locally using direct MoveIt objects.  This library assumes that MoveIt is being used in a broader ROS system (i.e. certain parameters, like robot_description exist)</description>
-  
-  <license>Apache 2.0</license> <!-- moveit_simple --> 
+
+  <license>Apache 2.0</license> <!-- moveit_simple -->
   <license>Boost Software License</license> <!-- prettyprint -->
-  
+
   <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
   <author>Shaun Edwards</author>
 

--- a/moveit_simple/src/online_robot.cpp
+++ b/moveit_simple/src/online_robot.cpp
@@ -29,7 +29,7 @@
 namespace moveit_simple
 {
 OnlineRobot::OnlineRobot(const ros::NodeHandle &nh, const std::string &robot_description,
-  const std::string &group_name) : Robot(nh, robot_description, group_name), 
+  const std::string &group_name) : Robot(nh, robot_description, group_name),
   action_("joint_trajectory_action", true)
 {
   current_robot_state_.reset(new moveit::core::RobotState(robot_model_ptr_));
@@ -139,7 +139,7 @@ void OnlineRobot::execute(std::vector<moveit_simple::JointTrajectoryPoint> &join
   }
   else
   {
-    ROS_ERROR_STREAM("Collision detected at " << collision_points 
+    ROS_ERROR_STREAM("Collision detected at " << collision_points
       << " points for Joint Trajectory");
     throw CollisionDetected("Collision detected while interpolating ");
   }

--- a/moveit_simple/test/kuka_kr210.cpp
+++ b/moveit_simple/test/kuka_kr210.cpp
@@ -37,7 +37,7 @@ class UserRobotTest : public ::testing::Test
 protected:
   std::unique_ptr<moveit_simple::OnlineRobot> robot;
   virtual void SetUp()
-  {      
+  {
   robot = std::unique_ptr<moveit_simple::OnlineRobot> (new moveit_simple::OnlineRobot
                   (ros::NodeHandle(), "robot_description", "manipulator"));
   ros::Duration(2.0).sleep();  //wait for tf tree to populate
@@ -62,7 +62,7 @@ public:
   using moveit_simple::OnlineRobot::cartesianInterpolation;
   using moveit_simple::OnlineRobot::isInCollision;
 };
-  
+
 /**
  * @brief DeveloperRobotTest is a fixture for testing protected methods.
  * Objects that can be directly used inside the test
@@ -74,7 +74,7 @@ class DeveloperRobotTest : public ::testing::Test
 protected:
   std::unique_ptr<DeveloperRobot> robot2;
   virtual void SetUp()
-  {      
+  {
   robot2 = std::unique_ptr<DeveloperRobot> (new DeveloperRobot
                   (ros::NodeHandle(), "robot_description", "manipulator"));
   ros::Duration(2.0).sleep();  //wait for tf tree to populate
@@ -87,7 +87,7 @@ protected:
 
 TEST(MoveitSimpleTest, construction_robot)
 {
-  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");  
+  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");
 }
 
 
@@ -100,7 +100,7 @@ TEST(MoveitSimpleTest, construction_online_robot)
 TEST(MoveitSimpleTest, reachability)
 {
   moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity(); 
+  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
   ros::Duration(2.0).sleep();  //wait for tf tree to populate
 
   ROS_INFO_STREAM("Testing reachability of unknown point, should fail");
@@ -122,7 +122,7 @@ TEST(MoveitSimpleTest, reachability)
 TEST_F(UserRobotTest, add_trajectory)
 {
   const std::string TRAJECTORY_NAME("traj1");
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity(); 
+  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
   const moveit_simple::InterpolationType cart = moveit_simple::interpolation_type::CARTESIAN;
   const moveit_simple::InterpolationType joint = moveit_simple::interpolation_type::JOINT;
 
@@ -131,13 +131,13 @@ TEST_F(UserRobotTest, add_trajectory)
   EXPECT_THROW(robot->addTrajPoint(TRAJECTORY_NAME, pose, "random_link", 5.0), tf2::TransformException);
   ROS_INFO_STREAM("Testing trajectory adding of points");
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "home",      0.5));
-  
+
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint1", 1.0, joint, 5));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "tf_pub1", 2.0, cart, 8));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint2", 3.0));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint3", 4.0, joint));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, pose, "tool0", 5.0));
-  
+
   EXPECT_NO_THROW(robot->execute(TRAJECTORY_NAME));
 
   EXPECT_NO_THROW(robot->addTrajPoint("traj2", "waypoint4", 4.5));
@@ -176,7 +176,7 @@ TEST_F(DeveloperRobotTest, planning)
 
   EXPECT_TRUE(robot2->getJointSolution(cart_interpolated_expected_pose, 3.0, seed, cart_interpolated_expected_joint));
 
-  // joint_point1,joint_point4, cart_point1 and cart_point3 
+  // joint_point1,joint_point4, cart_point1 and cart_point3
   // represent the same pose
   // joint_point2, cart_point2 and joint_point3 represent the same pose
   std::unique_ptr<moveit_simple::TrajectoryPoint> joint_point1 =
@@ -432,7 +432,7 @@ TEST_F(UserRobotTest, speed_reconfiguration)
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "tf_pub1",   2.0));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint2", 3.0));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint3", 4.0));
-  
+
   // Test 1 -- Max_Execution_Speed: Plan & then Execute that Plan separately
   robot->setSpeedModifier(1.0);
   EXPECT_TRUE(robot->getSpeedModifier() == 1.0);
@@ -440,11 +440,11 @@ TEST_F(UserRobotTest, speed_reconfiguration)
   std::vector<moveit_simple::JointTrajectoryPoint> goal;
 
   EXPECT_NO_THROW(goal = robot->plan(TRAJECTORY_NAME));
-  EXPECT_NO_THROW(robot->execute(goal));  
-  
+  EXPECT_NO_THROW(robot->execute(goal));
+
   execution_time_check_1 = goal[goal.size()-1].time();
   EXPECT_TRUE(execution_time_check_1 >= 0.0);
-  ROS_INFO_STREAM("Time for single traj. execution at MAX speed: " 
+  ROS_INFO_STREAM("Time for single traj. execution at MAX speed: "
     << execution_time_check_1 << " seconds");
 
   // Test 2 -- Half_Execution_Speed: Plan & Execute
@@ -482,12 +482,12 @@ TEST_F(UserRobotTest, speed_reconfiguration)
   delta_time_for_speed_limits = delta_max_half_speeds - delta_half_min_speeds;
   EXPECT_NEAR(delta_time_for_speed_limits, 0.0, execution_time_tolerance);
 
-  if(abs(delta_time_for_speed_limits) > execution_time_tolerance) 
+  if(abs(delta_time_for_speed_limits) > execution_time_tolerance)
   {
-    ROS_ERROR_STREAM("Time diff between [MAX_SPEED/REGULAR_SPEED] --> [" << 
-                     execution_time_check_1 << ", " << execution_time_check_2 << 
+    ROS_ERROR_STREAM("Time diff between [MAX_SPEED/REGULAR_SPEED] --> [" <<
+                     execution_time_check_1 << ", " << execution_time_check_2 <<
                      "] & [REGULAR_SPEED/MIN_SPEED] --> [" << execution_time_check_2 <<
-                     ", " << execution_time_check_3 << "] is " << delta_time_for_speed_limits << 
+                     ", " << execution_time_check_3 << "] is " << delta_time_for_speed_limits <<
                      "; but tolerance limit is [" << execution_time_tolerance << "]");
   }
 }
@@ -623,7 +623,7 @@ TEST_F(UserRobotTest, custom_tool_link)
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint3", "tool_custom", 4.0));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint1", tool_name, 5.0, joint, 5));
   EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, pose_eigen, "tool0", 6.0));
-  
+
   EXPECT_NO_THROW(robot->execute(TRAJECTORY_NAME));
 }
 

--- a/moveit_simple/test/launch/kuka_kr210.launch
+++ b/moveit_simple/test/launch/kuka_kr210.launch
@@ -20,7 +20,7 @@
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find moveit_simple)/test/resources/kuka_kr210/kuka_kr210.srdf" />
-  
+
   <!-- Load updated joint limits (override information from URDF) -->
   <group ns="$(arg robot_description)_planning">
     <rosparam command="load" file="$(find moveit_simple)/test/resources/kuka_kr210/joint_limits.yaml"/>

--- a/moveit_simple/test/launch/motoman_mh5.launch
+++ b/moveit_simple/test/launch/motoman_mh5.launch
@@ -17,7 +17,7 @@
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find moveit_simple)/test/resources/motoman_mh5/config/motoman_mh5_robot.srdf" />
-  
+
   <!-- Load updated joint limits (override information from URDF) -->
   <group ns="$(arg robot_description)_planning">
     <rosparam command="load" file="$(find moveit_simple)/test/resources/motoman_mh5/config/joint_limits.yaml"/>

--- a/moveit_simple/test/motoman_mh5.cpp
+++ b/moveit_simple/test/motoman_mh5.cpp
@@ -35,12 +35,12 @@ class UserRobotTest : public ::testing::Test
 {
 protected:
   std::unique_ptr<moveit_simple::OnlineRobot> user_robot;
-  
+
   virtual void SetUp()
-  {      
+  {
     user_robot = std::unique_ptr<moveit_simple::OnlineRobot> (new moveit_simple::OnlineRobot
       (ros::NodeHandle(), "robot_description", "manipulator", "base_link", "link_t"));
-    
+
     ros::Duration(2.0).sleep();  //wait for tf tree to populate
   }
 
@@ -62,9 +62,9 @@ public:
   using moveit_simple::OnlineRobot::cartesianInterpolation;
   using moveit_simple::OnlineRobot::isInCollision;
   using moveit_simple::OnlineRobot::getFK;
-  using moveit_simple::OnlineRobot::getIK;  
+  using moveit_simple::OnlineRobot::getIK;
 };
-  
+
 /**
  * @brief DeveloperRobotTest is a fixture for testing protected methods.
  * Objects that can be directly used inside the test
@@ -75,7 +75,7 @@ class DeveloperRobotTest : public ::testing::Test
 protected:
   std::unique_ptr<DeveloperRobot> developer_robot;
   virtual void SetUp()
-  {      
+  {
     developer_robot = std::unique_ptr<DeveloperRobot> (new DeveloperRobot
       (ros::NodeHandle(), "robot_description", "manipulator", "base_link", "link_t"));
 
@@ -95,7 +95,7 @@ struct KinematicsTestData
 
   // Forward kinematics from base -> tool_custom
   std::vector<double> translation_tool_custom; // [x, y, z]
-  std::vector<double> rotation_tool_custom; // Quaternion [x, y, z, w]  
+  std::vector<double> rotation_tool_custom; // Quaternion [x, y, z, w]
 };
 
 TEST_F(DeveloperRobotTest, kinematics)
@@ -155,7 +155,7 @@ TEST_F(DeveloperRobotTest, kinematics)
     EXPECT_NEAR(tool_custom_translation.x(), pose.translation_tool_custom[0], ABS_ERROR);
     EXPECT_NEAR(tool_custom_translation.y(), pose.translation_tool_custom[1], ABS_ERROR);
     EXPECT_NEAR(tool_custom_translation.z(), pose.translation_tool_custom[2], ABS_ERROR);
-    
+
     Eigen::Quaterniond tool_custom_rotation = Eigen::Quaterniond(tool_custom_calculated_pose.linear());
     EXPECT_NEAR(tool_custom_rotation.x(), pose.rotation_tool_custom[0], ABS_ERROR);
     EXPECT_NEAR(tool_custom_rotation.y(), pose.rotation_tool_custom[1], ABS_ERROR);
@@ -174,12 +174,12 @@ TEST_F(DeveloperRobotTest, kinematics)
     EXPECT_NEAR(check_joint_translation.x(), pose.translation_tool_custom[0], ABS_ERROR);
     EXPECT_NEAR(check_joint_translation.y(), pose.translation_tool_custom[1], ABS_ERROR);
     EXPECT_NEAR(check_joint_translation.z(), pose.translation_tool_custom[2], ABS_ERROR);
-    
+
     Eigen::Quaterniond check_joint_rotation = Eigen::Quaterniond(check_joint_solution.linear());
     EXPECT_NEAR(check_joint_rotation.x(), pose.rotation_tool_custom[0], ABS_ERROR);
     EXPECT_NEAR(check_joint_rotation.y(), pose.rotation_tool_custom[1], ABS_ERROR);
     EXPECT_NEAR(check_joint_rotation.z(), pose.rotation_tool_custom[2], ABS_ERROR);
-    EXPECT_NEAR(check_joint_rotation.w(), pose.rotation_tool_custom[3], ABS_ERROR);    
+    EXPECT_NEAR(check_joint_rotation.w(), pose.rotation_tool_custom[3], ABS_ERROR);
   };
 
   testKinematics(pose_home);
@@ -192,7 +192,7 @@ TEST_F(DeveloperRobotTest, kinematics)
 
 TEST(MoveitSimpleTest, construction_robot)
 {
-  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");  
+  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");
 }
 
 TEST(MoveitSimpleTest, construction_online_robot)
@@ -202,19 +202,19 @@ TEST(MoveitSimpleTest, construction_online_robot)
 
 TEST(MoveitSimpleTest, construction_robot_ikfast)
 {
-  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator", 
-    "base_link", "link_t"); 
+  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator",
+    "base_link", "link_t");
 }
 
 TEST(MoveitSimpleTest, construction_online_robot_ikfast)
 {
-  moveit_simple::OnlineRobot online_robot(ros::NodeHandle(), "robot_description", "manipulator", 
+  moveit_simple::OnlineRobot online_robot(ros::NodeHandle(), "robot_description", "manipulator",
     "base_link", "link_t");
 }
 
 TEST_F(UserRobotTest, reachability)
 {
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity(); 
+  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
 
   ROS_INFO_STREAM("Testing reachability of unknown point, should fail");
   EXPECT_FALSE(user_robot->isReachable("unknown_name"));
@@ -233,14 +233,14 @@ TEST_F(UserRobotTest, reachability)
 TEST_F(UserRobotTest, add_trajectory)
 {
   const std::string TRAJECTORY_NAME("traj1");
-  const Eigen::Affine3d pose = Eigen::Affine3d::Identity(); 
+  const Eigen::Affine3d pose = Eigen::Affine3d::Identity();
   const moveit_simple::InterpolationType cart = moveit_simple::interpolation_type::CARTESIAN;
   const moveit_simple::InterpolationType joint = moveit_simple::interpolation_type::JOINT;
 
   ROS_INFO_STREAM("Testing loading of unknown point, should fail");
   EXPECT_THROW(user_robot->addTrajPoint("bad_traj", "unknown_name", 1.0), std::invalid_argument);
   EXPECT_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, pose, "random_link", 5.0), tf2::TransformException);
-  
+
   ROS_INFO_STREAM("Testing trajectory adding of points");
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "home", 0.5));
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "wp1", 1.0, joint, 5));
@@ -335,7 +335,7 @@ TEST_F(DeveloperRobotTest, planning)
   EXPECT_EQ(points.size(),14);
 
   ROS_INFO_STREAM("Converting the joint positions to poses to compare against expected poses");
-  
+
   std::vector<Eigen::Affine3d> pose_out;
   pose_out.resize(points.size());
   for (std::size_t i = 0; i < points.size(); ++i)
@@ -537,7 +537,7 @@ TEST_F(UserRobotTest, speed_reconfiguration)
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "tf_pub1",   2.0));
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "wp2", 3.0));
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "wp3", 4.0));
-  
+
   // Test 1 -- Max_Execution_Speed: Plan & then Execute that Plan separately
   user_robot->setSpeedModifier(1.0);
   EXPECT_TRUE(user_robot->getSpeedModifier() == 1.0);
@@ -545,11 +545,11 @@ TEST_F(UserRobotTest, speed_reconfiguration)
   std::vector<moveit_simple::JointTrajectoryPoint> goal;
 
   EXPECT_NO_THROW(goal = user_robot->plan(TRAJECTORY_NAME));
-  EXPECT_NO_THROW(user_robot->execute(goal));  
-  
+  EXPECT_NO_THROW(user_robot->execute(goal));
+
   execution_time_check_1 = goal[goal.size()-1].time();
   EXPECT_TRUE(execution_time_check_1 >= 0.0);
-  ROS_INFO_STREAM("Time for single traj. execution at MAX speed: " 
+  ROS_INFO_STREAM("Time for single traj. execution at MAX speed: "
     << execution_time_check_1 << " seconds");
 
   // Test 2 -- Half_Execution_Speed: Plan & Execute
@@ -587,12 +587,12 @@ TEST_F(UserRobotTest, speed_reconfiguration)
   delta_time_for_speed_limits = delta_max_half_speeds - delta_half_min_speeds;
   EXPECT_NEAR(delta_time_for_speed_limits, 0.0, execution_time_tolerance);
 
-  if(abs(delta_time_for_speed_limits) > execution_time_tolerance) 
+  if(abs(delta_time_for_speed_limits) > execution_time_tolerance)
   {
-    ROS_ERROR_STREAM("Time diff between [MAX_SPEED/REGULAR_SPEED] --> [" << 
-                     execution_time_check_1 << ", " << execution_time_check_2 << 
+    ROS_ERROR_STREAM("Time diff between [MAX_SPEED/REGULAR_SPEED] --> [" <<
+                     execution_time_check_1 << ", " << execution_time_check_2 <<
                      "] & [REGULAR_SPEED/MIN_SPEED] --> [" << execution_time_check_2 <<
-                     ", " << execution_time_check_3 << "] is " << delta_time_for_speed_limits << 
+                     ", " << execution_time_check_3 << "] is " << delta_time_for_speed_limits <<
                      "; but tolerance limit is [" << execution_time_tolerance << "]");
   }
 }
@@ -726,7 +726,7 @@ TEST_F(UserRobotTest, custom_tool_link)
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "wp3", "tool_custom", 4.0));
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "wp1", tool_name, 5.0, joint, 5));
   EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, pose_eigen, "tool0", 6.0));
-  
+
   EXPECT_NO_THROW(user_robot->execute(TRAJECTORY_NAME));
 }
 

--- a/moveit_simple/test/resources/kuka_kr210/kuka_custom_tool.urdf
+++ b/moveit_simple/test/resources/kuka_kr210/kuka_custom_tool.urdf
@@ -4,7 +4,7 @@
   <link name="tool0"/>
 
   <link name="tool_custom"/>
-  
+
   <joint name="tool0-tool_custom" type="fixed">
     <parent link="tool0"/>
     <child link="tool_custom"/>

--- a/moveit_simple/test/resources/motoman_mh5/config/ompl_planning.yaml
+++ b/moveit_simple/test/resources/motoman_mh5/config/ompl_planning.yaml
@@ -20,7 +20,7 @@ planner_configs:
   KPIECEkConfigDefault:
     type: geometric::KPIECE
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
-    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
     border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9 (0.0,1.]
     failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
     min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
@@ -44,7 +44,7 @@ planner_configs:
     temp_change_factor: 2.0  # how much to increase or decrease temp. default: 2.0
     min_temperature: 10e-10  # lower limit of temp change. default: 10e-10
     init_temperature: 10e-6  # initial temperature. default: 10e-6
-    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup()
     frountierNodeRatio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
     k_constant: 0.0  # value used to normalize expresssion. default: 0.0 set in setup()
   PRMkConfigDefault:
@@ -75,9 +75,9 @@ planner_configs:
   STRIDEkConfigDefault:
     type: geometric::STRIDE
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
-    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
     use_projected_distance: 0  # whether nearest neighbors are computed based on distances in a projection of the state rather distances in the state space itself. default: 0
-    degree: 16  # desired degree of a node in the Geometric Near-neightbor Access Tree (GNAT). default: 16 
+    degree: 16  # desired degree of a node in the Geometric Near-neightbor Access Tree (GNAT). default: 16
     max_degree: 18  # max degree of a node in the GNAT. default: 12
     min_degree: 12  # min degree of a node in the GNAT. default: 12
     max_pts_per_leaf: 6  # max points per leaf in the GNAT. default: 6
@@ -88,13 +88,13 @@ planner_configs:
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
     temp_change_factor: 0.1  # how much to increase or decrease temp. default: 0.1
     init_temperature: 100  # initial temperature. default: 100
-    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup() 
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup()
     frountier_node_ratio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
     cost_threshold: 1e300  # the cost threshold. Any motion cost that is not better will not be expanded. default: inf
   LBTRRTkConfigDefault:
     type: geometric::LBTRRT
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
-    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
     epsilon: 0.4  # optimality approximation factor. default: 0.4
   BiESTkConfigDefault:
     type: geometric::BiEST
@@ -102,7 +102,7 @@ planner_configs:
   ProjESTkConfigDefault:
     type: geometric::ProjEST
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
-    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05 
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
   LazyPRMkConfigDefault:
     type: geometric::LazyPRM
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()

--- a/moveit_simple/test/resources/motoman_mh5/urdf/motoman_mh5_robot_macro.xacro
+++ b/moveit_simple/test/resources/motoman_mh5/urdf/motoman_mh5_robot_macro.xacro
@@ -50,7 +50,7 @@
       <parent link="${prefix}ee_link"/>
       <child link="${prefix}tool_custom"/>
       <origin rpy="0 0 0" xyz="0 0 0.15"/>
-    </joint>    
+    </joint>
     <!-- End Joints -->
 
     <!-- Waypoints for testing -->

--- a/moveit_simple_msgs/package.xml
+++ b/moveit_simple_msgs/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="aaronwood@plusonerobotics.com">Aaron Wood</maintainer>
 
-  <license>Apache 2.0</license> <!-- moveit_simple_msgs --> 
+  <license>Apache 2.0</license> <!-- moveit_simple_msgs -->
   <license>Boost Software License</license> <!-- prettyprint -->
 
   <author email="aaronwood@plusonerobotics.com">Aaron Wood</author>


### PR DESCRIPTION
This PR removes the trailing whitespace across the code base. It was done with this command. 

```bash
find . \( -name '*.h' -o -name '*.hpp' -o -name '*.cpp' -o -name '*.c' -o -name '*.markdown' -o -name '*.md' -o -name '*.xml' -o -name '*.m' -o -name '*.txt' -o -name '*.sh' -o -name '*.launch' -o -name '*.world' -o -name '*.urdf' -o -name '*.xacro' -o -name '*.py' -o -name '*.cfg' -o -name '*.msg' -o -name '*.yml' -o -name '*.yaml' -o -name '*.rst' \) -exec sed -i 's/ *$//' '{}' ';'
```