### PR TITLE
separate out simple type conversions

### DIFF
--- a/moveit_simple/CMakeLists.txt
+++ b/moveit_simple/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(${PROJECT_NAME}
   src/online_robot.cpp
   src/point_types.cpp
   src/robot.cpp
+  src/conversions.cpp
 )
 
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})

--- a/moveit_simple/include/moveit_simple/conversions.h
+++ b/moveit_simple/include/moveit_simple/conversions.h
@@ -1,0 +1,46 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016 Shaun Edwards
+ * Copyright (c) 2018 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CONVERSIONS_H
+#define CONVERSIONS_H
+
+#include <trajectory_msgs/JointTrajectoryPoint.h>
+
+#include <moveit_simple/point_types.h>
+
+
+namespace moveit_simple
+{
+  /**
+   * @brief toJointTrajPtMsg - Converts native joint point (vector + time) to ROS joint
+   * trajectory point message type.
+   * @param joint_point
+   * @param time
+   * @return
+   */
+  trajectory_msgs::JointTrajectoryPoint toJointTrajPtMsg(const std::vector<double> &joint_point,
+    double time);
+
+  trajectory_msgs::JointTrajectoryPoint toJointTrajPtMsg(const JointTrajectoryPoint &joint_point);
+
+  std::vector<moveit_simple::JointTrajectoryPoint>
+  toJointTrajectoryPoint(std::vector<trajectory_msgs::JointTrajectoryPoint>& ros_joint_trajectory_points);
+
+} // namespace moveit_simple
+#endif // CONVERSIONS_H

--- a/moveit_simple/include/moveit_simple/conversions.h
+++ b/moveit_simple/include/moveit_simple/conversions.h
@@ -1,8 +1,7 @@
 /*
  * Software License Agreement (Apache License)
  *
- * Copyright (c) 2016 Shaun Edwards
- * Copyright (c) 2018 Plus One Robotics
+ * Copyright (c) 2019 Plus One Robotics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -473,9 +473,6 @@ protected:
   Eigen::Affine3d transformPoseBetweenFrames(const Eigen::Affine3d &target_pose,
     const std::string &frame_in, const std::string &frame_out) const;
 
-  std::vector<moveit_simple::JointTrajectoryPoint> toJointTrajectoryPoint(
-    std::vector<trajectory_msgs::JointTrajectoryPoint> &ROS_joint_trajectory_points) const;
-
   control_msgs::FollowJointTrajectoryGoal toFollowJointTrajectoryGoal(
     const std::vector<moveit_simple::JointTrajectoryPoint> &joint_trajectory_points) const;
 
@@ -568,18 +565,6 @@ protected:
     double time) const;
 
   bool isConfigChange(const std::vector<double> jp1, const std::vector<double> jp2) const;
-
-  /**
-   * @brief toJointTrajPtMsg - Converts native joint point (vector + time) to ROS joint
-   * trajectory point message type.
-   * @param joint_point
-   * @param time
-   * @return
-   */
-  static trajectory_msgs::JointTrajectoryPoint toJointTrajPtMsg(const std::vector<double> &joint_point,
-    double time);
-
-  trajectory_msgs::JointTrajectoryPoint toJointTrajPtMsg(const JointTrajectoryPoint &joint_point) const;
 
   // Dynamic Reconfigure callback
   void reconfigureRequest(moveit_simple_dynamic_reconfigure_Config &config, uint32_t level);

--- a/moveit_simple/src/conversions.cpp
+++ b/moveit_simple/src/conversions.cpp
@@ -1,8 +1,7 @@
 /*
  * Software License Agreement (Apache License)
  *
- * Copyright (c) 2016 Shaun Edwards
- * Copyright (c) 2018 Plus One Robotics
+ * Copyright (c) 2019 Plus One Robotics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/moveit_simple/src/conversions.cpp
+++ b/moveit_simple/src/conversions.cpp
@@ -1,0 +1,62 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016 Shaun Edwards
+ * Copyright (c) 2018 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <moveit_simple/conversions.h>
+
+
+namespace moveit_simple
+{
+  trajectory_msgs::JointTrajectoryPoint toJointTrajPtMsg(const std::vector<double> &joint_point,
+    double time)
+  {
+    trajectory_msgs::JointTrajectoryPoint rtn;
+    std::vector<double> empty(joint_point.size(), 0.0);
+
+    rtn.positions = joint_point;
+    rtn.velocities = empty;
+
+    rtn.accelerations = empty;
+    rtn.effort = empty;
+    rtn.time_from_start = ros::Duration(time);
+
+    return rtn;
+  }
+
+  trajectory_msgs::JointTrajectoryPoint toJointTrajPtMsg(const JointTrajectoryPoint &joint_point)
+  {
+    return toJointTrajPtMsg(joint_point.jointPoint(), joint_point.time());
+  }
+
+  std::vector<moveit_simple::JointTrajectoryPoint>
+  toJointTrajectoryPoint(std::vector<trajectory_msgs::JointTrajectoryPoint>& ros_joint_trajectory_points)
+  {
+    std::vector<moveit_simple::JointTrajectoryPoint> goal;
+    goal.reserve(ros_joint_trajectory_points.size());
+
+    for (std::size_t i = 0; i < ros_joint_trajectory_points.size(); i++)
+    {
+      JointTrajectoryPoint point(ros_joint_trajectory_points[i].positions,
+                                 ros_joint_trajectory_points[i].time_from_start.toSec(), "");
+      goal.push_back(point);
+    }
+
+    return goal;
+  }
+
+} // namespace moveit_simple

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -32,6 +32,7 @@
 #include <moveit_simple/joint_locker.h>
 #include <moveit_simple/point_types.h>
 #include <moveit_simple/prettyprint.hpp>
+#include <moveit_simple/conversions.h>
 #include <moveit_simple/robot.h>
 
 namespace moveit_simple
@@ -886,22 +887,6 @@ std::vector<moveit_simple::JointTrajectoryPoint> Robot::plan(const std::string t
   }
 }
 
-std::vector<moveit_simple::JointTrajectoryPoint>
-Robot::toJointTrajectoryPoint(std::vector<trajectory_msgs::JointTrajectoryPoint>& ros_joint_trajectory_points) const
-{
-  std::vector<moveit_simple::JointTrajectoryPoint> goal;
-  goal.reserve(ros_joint_trajectory_points.size());
-
-  for (std::size_t i = 0; i < ros_joint_trajectory_points.size(); i++)
-  {
-    JointTrajectoryPoint point(ros_joint_trajectory_points[i].positions,
-                               ros_joint_trajectory_points[i].time_from_start.toSec(), "");
-    goal.push_back(point);
-  }
-
-  return goal;
-}
-
 control_msgs::FollowJointTrajectoryGoal Robot::toFollowJointTrajectoryGoal(
     const std::vector<moveit_simple::JointTrajectoryPoint>& joint_trajectory_points) const
 {
@@ -1569,26 +1554,6 @@ bool Robot::isNearSingular(const std::vector<double>& joint_point) const
                                                << " is not a chain");
     return false;
   }
-}
-
-trajectory_msgs::JointTrajectoryPoint Robot::toJointTrajPtMsg(const JointTrajectoryPoint& joint_point) const
-{
-  return toJointTrajPtMsg(joint_point.jointPoint(), joint_point.time());
-}
-
-trajectory_msgs::JointTrajectoryPoint Robot::toJointTrajPtMsg(const std::vector<double>& joint_point, double time)
-{
-  trajectory_msgs::JointTrajectoryPoint rtn;
-  std::vector<double> empty(joint_point.size(), 0.0);
-
-  rtn.positions = joint_point;
-  rtn.velocities = empty;
-
-  rtn.accelerations = empty;
-  rtn.effort = empty;
-  rtn.time_from_start = ros::Duration(time);
-
-  return rtn;
 }
 
 std::vector<double> Robot::getJointState(void) const


### PR DESCRIPTION
This should target a devel branch once it is made

This PR separates out simple conversions from the robot class. This is part of a larger effort to upgrade the trajectory planning capabilities.