### PR TITLE
Trajectory planning

### DIFF
--- a/moveit_simple/CMakeLists.txt
+++ b/moveit_simple/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(${PROJECT_NAME}
   src/online_robot.cpp
   src/point_types.cpp
   src/robot.cpp
+  src/trajectory_planner.cpp
   src/conversions.cpp
 )
 

--- a/moveit_simple/include/moveit_simple/point_types.h
+++ b/moveit_simple/include/moveit_simple/point_types.h
@@ -30,6 +30,7 @@
 namespace moveit_simple
 {
 class Robot;
+class TrajectoryPlanner;
 class TrajectoryPoint;
 class JointTrajectoryPoint;
 class CartTrajectoryPoint;
@@ -60,6 +61,8 @@ class TrajectoryPoint
 {
 public:
   friend class Robot;
+  friend class TrajectoryPlanner;
+
 
   virtual ~TrajectoryPoint() { }
 

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -34,6 +34,7 @@
 
 #include <moveit_simple/moveit_simple_dynamic_reconfigure_Parameters.h>
 #include <moveit_simple/point_types.h>
+#include <moveit_simple/trajectory_planner.h>
 
 namespace moveit_simple
 {
@@ -48,6 +49,8 @@ namespace moveit_simple
 class Robot
 {
 public:
+  friend class TrajectoryPlanner;
+
   /**
   * @brief Constructor
   */
@@ -374,7 +377,8 @@ public:
    * @brief clearTrajectory - clears stored trajectory
    * @param traj_name - trajectory to clear
    */
-  void clearTrajectory(const ::std::string traj_name);
+  // TODO(mlautman): deprecate this
+  void clearTrajectory(const ::std::string& traj_name);
 
   /**
    * @brief plan out a given trajectory
@@ -476,6 +480,7 @@ protected:
   control_msgs::FollowJointTrajectoryGoal toFollowJointTrajectoryGoal(
     const std::vector<moveit_simple::JointTrajectoryPoint> &joint_trajectory_points) const;
 
+  // TODO(mlautman): Deprecate this
   bool toJointTrajectory(const std::string traj_name, std::vector<trajectory_msgs::JointTrajectoryPoint> &points,
     bool collision_check = false);
 
@@ -535,6 +540,7 @@ protected:
     const std::unique_ptr<JointTrajectoryPoint> &to, double t,
     std::unique_ptr<JointTrajectoryPoint> &point) const;
 
+  // TODO(mlautman): deprecate this
   void addTrajPoint(const std::string &traj_name, std::unique_ptr<TrajectoryPoint> &point,
     const InterpolationType &type = interpolation_type::JOINT,
     const unsigned int num_steps = 0);
@@ -570,7 +576,7 @@ protected:
   void reconfigureRequest(moveit_simple_dynamic_reconfigure_Config &config, uint32_t level);
 
   // Robot internal objects
-  std::map<std::string, TrajectoryInfo> traj_info_map_;
+  TrajectoryPlanner trajectory_planner_;
 
   // MoveIt objects
   mutable moveit::core::RobotStatePtr virtual_robot_state_;  // for IK calls

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -540,7 +540,6 @@ protected:
     const std::unique_ptr<JointTrajectoryPoint> &to, double t,
     std::unique_ptr<JointTrajectoryPoint> &point) const;
 
-  // TODO(mlautman): deprecate this
   void addTrajPoint(const std::string &traj_name, std::unique_ptr<TrajectoryPoint> &point,
     const InterpolationType &type = interpolation_type::JOINT,
     const unsigned int num_steps = 0);

--- a/moveit_simple/include/moveit_simple/trajectory_planner.h
+++ b/moveit_simple/include/moveit_simple/trajectory_planner.h
@@ -1,8 +1,7 @@
 /*
  * Software License Agreement (Apache License)
  *
- * Copyright (c) 2016 Shaun Edwards
- * Copyright (c) 2018 Plus One Robotics
+ * Copyright (c) 2019 Plus One Robotics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/moveit_simple/include/moveit_simple/trajectory_planner.h
+++ b/moveit_simple/include/moveit_simple/trajectory_planner.h
@@ -1,0 +1,132 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016 Shaun Edwards
+ * Copyright (c) 2018 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TRAJECTORY_PLANNER_H
+#define TRAJECTORY_PLANNER_H
+
+#include <mutex>
+
+#include <ros/ros.h>
+
+#include <moveit_simple/point_types.h>
+#include <moveit_simple/exceptions.h>
+
+#include <trajectory_msgs/JointTrajectoryPoint.h>
+
+
+namespace moveit_simple {
+class Robot;
+
+/**
+ * @brief TrajectoryPlanner manages the generation, lookup and planning of trajectories.
+ * Assumptions are:
+ *  - single arm manipulator (one joint group)
+ *  - all cartesian poses are of the tool of the robot (could be fixed in the future)
+ *  - point names are stored as joint positions in the SRDF or frame names in the
+ * URDF
+ * - frame transformations outside the URDF are provided by TF
+ */
+
+class TrajectoryPlanner {
+public:
+  /**
+  * @brief Constructor
+  */
+  TrajectoryPlanner()
+  {
+  }
+
+  /**
+  * @brief Destructor
+  */
+  ~TrajectoryPlanner(){}
+
+  void addTrajPoint(const std::string &traj_name, std::unique_ptr<TrajectoryPoint> &point,
+    const InterpolationType &type = interpolation_type::JOINT,
+    const unsigned int num_steps = 0);
+
+  /**
+   * @brief clearTrajectory - clears stored trajectory
+   * @param traj_name - trajectory to clear
+   */
+  void clearTrajectory(const ::std::string& traj_name);
+
+  /**
+   * @brief plan out a given trajectory
+   * @param robot - Robot to be used for planning
+   * @param traj_name - name of trajectory to be executed (must be filled with
+   * prior calls to "addTrajPoint".
+   * @param collision_check - bool to turn check for collision on\off
+   * @throws <moveit_simple::IKFailException> (Conversion to joint trajectory failed)
+   * @throws <std::invalid_argument> (Trajectory "traj_name" not found)
+   * @throws <moveit_simple::CollisionDetected> (One of interpolated point is
+   * in Collision with itself or environment)
+   */
+  std::vector<moveit_simple::JointTrajectoryPoint> plan(
+    Robot& robot,
+    const std::string traj_name, bool collision_check = false);
+
+  /**
+   * @brief  jointInterpolation - joint Interpolation from last added point to
+   * current trajectory point(traj_point).
+   * @param robot - Robot to be used for planning
+   * @param traj_point: target traj_point for joint interpolation
+   * @param points: Vector of Joint Trajectory Point to be executed. We append new points in place
+   *                This Vector must not be empty and it should have the current pose at index 0.
+   * @param num_steps: number of steps to be interpolated between current point and traj_point
+   * @param collision_check - bool to turn check for collision on\off
+   * @return true if all the points including traj_point are added to the points.
+   */
+  bool jointInterpolation(
+    Robot& robot,
+    const std::unique_ptr<TrajectoryPoint> &traj_point,
+    std::vector<trajectory_msgs::JointTrajectoryPoint> &points, const unsigned int num_steps,
+    bool collision_check = false);
+
+  /**
+   * @brief  cartesianInterpolation - Cartesian Interpolation from last added point to
+   * current trajectory point(traj_point).
+   * @param robot - Robot to be used for planning
+   * @param traj_point: target traj_point for cartesian interpolation
+   * @param points: Vector of Joint Trajectory Point to be executed
+   * @param num_steps: number of steps to be interpolated between current point and traj_point
+   * @param collision_check - bool to turn check for collision on\off
+   * @return true if all the points including traj_point are added to the points.
+   */
+  bool cartesianInterpolation(Robot& robot,
+    const std::unique_ptr<TrajectoryPoint> &traj_point,
+    std::vector<trajectory_msgs::JointTrajectoryPoint> &points, const unsigned int num_steps,
+    bool collision_check = false);
+
+
+  bool toJointTrajectory(
+    Robot& robot,
+    const std::string traj_name,
+    std::vector<trajectory_msgs::JointTrajectoryPoint> &points,
+    bool collision_check = false);
+
+
+  // Trajectory storage
+  std::map<std::string, TrajectoryInfo> traj_info_map_;
+  mutable std::recursive_mutex trajectory_info_map_mutex_;
+private:
+
+};
+} // namespace moveit_simple
+#endif // TRAJECTORY_PLANNER_H

--- a/moveit_simple/launch/kuka_kr210_demo.launch
+++ b/moveit_simple/launch/kuka_kr210_demo.launch
@@ -23,6 +23,8 @@
     <arg name="run_test_node" value="$(arg run_test_node)"/>
   </include>
 
+  <node pkg="tf" type="static_transform_publisher" name="tfdummy" args="0 0 0 0 0 0 /world /base_link 10" />
+
   <!-- Test Node -->
   <node name="kuka_kr210_demo" pkg="moveit_simple" type="moveit_simple_trajectory_planner_demo"
   launch-prefix="$(arg launch_prefix)" />

--- a/moveit_simple/scripts/trajectory_planner_demo.cpp
+++ b/moveit_simple/scripts/trajectory_planner_demo.cpp
@@ -43,6 +43,9 @@ int main(int argc, char **argv)
   robot->addTrajPoint(trajectory_name, "tf_pub1",   2.0, cart, 8);
   robot->addTrajPoint(trajectory_name, "waypoint2", 3.0);
   robot->addTrajPoint(trajectory_name, "waypoint3", 4.0, joint);
+  robot->addTrajPoint(trajectory_name, "waypoint1", 4.0, joint);
+  robot->addTrajPoint(trajectory_name, "waypoint3", 4.0, cart);
+  robot->addTrajPoint(trajectory_name, "waypoint1", 4.0, cart);
   robot->addTrajPoint(trajectory_name, pose, "tool0", 5.0);
 
   robot->execute(trajectory_name);

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -272,7 +273,7 @@ void Robot::addTrajPoint(const std::string& traj_name, const std::string& point_
 void Robot::addTrajPoint(const std::string& traj_name, std::unique_ptr<TrajectoryPoint>& point,
                          const InterpolationType& type, const unsigned int num_steps)
 {
-  traj_info_map_[traj_name].push_back({ std::move(point), type, num_steps });
+  trajectory_planner_.addTrajPoint(traj_name, point, type, num_steps);
 }
 
 void Robot::addTrajPointJointLock(const std::string& traj_name, const std::string& point_name, double time,
@@ -838,53 +839,14 @@ bool Robot::isReachable(std::unique_ptr<TrajectoryPoint>& point, double timeout,
   return reachable;
 }
 
-void Robot::clearTrajectory(const ::std::string traj_name)
+void Robot::clearTrajectory(const std::string& traj_name)
 {
-  std::lock_guard<std::recursive_mutex> guard(m_);
-  traj_info_map_.erase(traj_name);
+  trajectory_planner_.clearTrajectory(traj_name);
 }
 
 std::vector<moveit_simple::JointTrajectoryPoint> Robot::plan(const std::string traj_name, bool collision_check)
 {
-  std::lock_guard<std::recursive_mutex> guard(m_);
-
-  if (traj_info_map_.count(traj_name))
-  {
-    std::vector<trajectory_msgs::JointTrajectoryPoint> ROS_trajectory_points;
-
-    try
-    {
-      if (toJointTrajectory(traj_name, ROS_trajectory_points, collision_check))
-      {
-        // Modify the speed of execution for the trajectory based off of the speed_modifier_
-        for (std::size_t i = 0; i < ROS_trajectory_points.size(); i++)
-        {
-          ROS_trajectory_points[i].time_from_start *= (1.0 / speed_modifier_);
-        }
-
-        std::vector<moveit_simple::JointTrajectoryPoint> goal = toJointTrajectoryPoint(ROS_trajectory_points);
-
-        ROS_INFO_STREAM("Successfully planned out trajectory: [" << traj_name << "]");
-
-        return goal;
-      }
-      else
-      {
-        ROS_ERROR_STREAM("Failed to convert [" << traj_name << "] to joint trajectory");
-        throw IKFailException("Conversion to joint trajectory failed for " + traj_name);
-      }
-    }
-    catch (CollisionDetected& cd)
-    {
-      ROS_ERROR_STREAM("Collision detected in [" << traj_name << "]");
-      throw cd;
-    }
-  }
-  else
-  {
-    ROS_ERROR_STREAM("Trajectory [" << traj_name << "] not found");
-    throw std::invalid_argument("No trajectory found named " + traj_name);
-  }
+  return trajectory_planner_.plan(*this, traj_name, collision_check);
 }
 
 control_msgs::FollowJointTrajectoryGoal Robot::toFollowJointTrajectoryGoal(
@@ -970,49 +932,7 @@ double Robot::getSpeedModifier(void) const
 bool Robot::toJointTrajectory(const std::string traj_name, std::vector<trajectory_msgs::JointTrajectoryPoint>& points,
                               bool collision_check)
 {
-  const TrajectoryInfo& traj_info = traj_info_map_[traj_name];
-
-  // The first point in any trajectory is the current pose
-  std::vector<double> current_joint_position = getJointState();
-  points.push_back(toJointTrajPtMsg(current_joint_position, 0.0));
-
-  for (size_t i = 0; i < traj_info.size(); ++i)
-  {
-    const std::unique_ptr<TrajectoryPoint>& traj_point = traj_info[i].point;
-    if (traj_info[i].type == interpolation_type::JOINT)
-    {
-      if (jointInterpolation(traj_point, points, traj_info[i].num_steps, collision_check))
-      {
-        ROS_INFO_STREAM("Trajectory successfully added till " << traj_point->name());
-      }
-      else
-      {
-        ROS_ERROR_STREAM("Conversion to joint trajectory failed for " << traj_name << " due to IK failure of "
-                                                                      << traj_point->name());
-        return false;
-      }
-    }
-    else if (traj_info[i].type == interpolation_type::CARTESIAN)
-    {
-      if (cartesianInterpolation(traj_point, points, traj_info[i].num_steps, collision_check))
-      {
-        ROS_INFO_STREAM("Trajectory successfully added till " << traj_point->name());
-      }
-      else
-      {
-        ROS_ERROR_STREAM("Conversion to joint trajectory failed for " << traj_name << " before adding "
-                                                                      << traj_point->name());
-        return false;
-      }
-    }
-    else
-    {
-      ROS_ERROR_STREAM("Unknown interpolation call " << traj_info[i].type);
-      return false;
-    }
-  }
-
-  return true;
+  return trajectory_planner_.toJointTrajectory(*this, traj_name, points, collision_check);
 }
 
 void Robot::computeIKSolverTransforms()
@@ -1068,177 +988,75 @@ bool Robot::jointInterpolation(const std::unique_ptr<TrajectoryPoint>& traj_poin
                                std::vector<trajectory_msgs::JointTrajectoryPoint>& points, unsigned int num_steps,
                                bool collision_check)
 {
-  const double IK_TIMEOUT = 0.250;  // 250 ms for IK solving
-
-  auto options = traj_point->getJointLockOptions();
-
-  // Create a local vector for storing interpolated points
-  std::vector<trajectory_msgs::JointTrajectoryPoint> points_local;
-  trajectory_msgs::JointTrajectoryPoint prev_point_info = points.back();
-  std::vector<double> prev_point = prev_point_info.positions;
-  double prev_time = prev_point_info.time_from_start.toSec();
-
-  // Convert the previous point stored in points to Joint Trajectory Point
-  std::unique_ptr<JointTrajectoryPoint> prev_traj_point =
-      std::unique_ptr<JointTrajectoryPoint>(new JointTrajectoryPoint(prev_point, prev_time, ""));
-
-  std::unique_ptr<JointTrajectoryPoint> target_point;
-  if (traj_point->type() != TrajectoryPoint::JOINT)
-  {
-    const size_t MAX_IK_ATTEMPTS = 2;
-    size_t num_attempts = 0;
-
-    while (true)
-    {
-      num_attempts++;
-      target_point = traj_point->toJointTrajPoint(*this, IK_TIMEOUT, prev_point);
-
-      if (target_point)
-      {
-        if (isConfigChange(prev_point, target_point->jointPoint()))
-        {
-          ROS_WARN_STREAM("Configuration change detected in move to/from cart point: ("
-                          << traj_point->name() << "), of type: " << traj_point->type() << " to joint trajectory");
-        }
-        else
-        {
-          ROS_INFO_STREAM("Found proper IK (no config change) in " << num_attempts << " attempts");
-          break;
-        }
-      }
-      else
-      {
-        ROS_WARN_STREAM("Failed to convert trajectory point:  ("
-                        << traj_point->name() << "), of type: " << traj_point->type() << " to joint trajectory");
-        return false;
-      }
-      if (num_attempts >= MAX_IK_ATTEMPTS)
-      {
-        ROS_ERROR_STREAM("Failed to find proper IK (no config change) in " << num_attempts << " attempts");
-        return false;
-      }
-    }
-  }
-  else
-  {
-    target_point = traj_point->toJointTrajPoint(*this, IK_TIMEOUT, prev_point);
-    if (!target_point)
-    {
-      ROS_WARN_STREAM("Failed to convert joint point - this shouldn't happen");
-      return false;
-    }
-  }
-
-  unsigned int points_added = 0;
-  for (std::size_t i = 1; i <= num_steps + 1; ++i)
-  {
-    double t = (double)i / (double)(num_steps + 1);
-    std::unique_ptr<JointTrajectoryPoint> new_point;
-    interpolate(prev_traj_point, target_point, t, new_point);
-    if (new_point)
-    {
-      if ((collision_check) && (isInCollision(new_point->jointPoint())))
-      {
-        ROS_WARN_STREAM("Collision detected at " << points_added << " among " << (num_steps + 1) << " points for "
-                                                 << traj_point->name());
-        points_local.clear();
-        throw CollisionDetected("Collision detected while interpolating " + traj_point->name());
-      }
-      else
-      {
-        // Lock the joints
-        auto new_point_joints = new_point->jointPoint();
-        JointLocker::lockJoints(prev_point, new_point_joints, options);
-        auto locked_new_point =
-            std::unique_ptr<JointTrajectoryPoint>(new JointTrajectoryPoint(new_point_joints, new_point->time(), ""));
-
-        points_local.push_back(toJointTrajPtMsg(*locked_new_point));
-        points_added++;
-        ROS_INFO_STREAM(points_added << " points among " << (num_steps + 1) << " successfully interpolated for "
-                                     << traj_point->name());
-      }
-    }
-    else
-    {
-      ROS_WARN_STREAM("Conversion to joint trajectory failed at " << points_added << " among " << (num_steps + 1)
-                                                                  << "points for " << traj_point->name()
-                                                                  << ". Exiting without interpolation");
-      points_local.clear();
-      return false;
-    }
-  }
-  // Append the global points with local_points
-  points.insert(points.end(), points_local.begin(), points_local.end());
-  ROS_INFO_STREAM("Appending trajectory point, size: " << points.size());
-  points_local.clear();
-  return true;
+  return trajectory_planner_.jointInterpolation(*this, traj_point, points, num_steps, collision_check);
 }
 
 bool Robot::cartesianInterpolation(const std::unique_ptr<TrajectoryPoint>& traj_point,
                                    std::vector<trajectory_msgs::JointTrajectoryPoint>& points, unsigned int num_steps,
                                    bool collision_check)
 {
-  // Create a local vector for storing interpolated points and append
-  // it with last element of global points to be used for interpolation
-  std::vector<trajectory_msgs::JointTrajectoryPoint> points_local;
-  points_local.clear();
-  points_local.push_back(points.back());
+  return trajectory_planner_.cartesianInterpolation(*this, traj_point, points, num_steps, collision_check);
+  // // Create a local vector for storing interpolated points and append
+  // // it with last element of global points to be used for interpolation
+  // std::vector<trajectory_msgs::JointTrajectoryPoint> points_local;
+  // points_local.clear();
+  // points_local.push_back(points.back());
 
-  trajectory_msgs::JointTrajectoryPoint prev_point_info = points.back();
+  // trajectory_msgs::JointTrajectoryPoint prev_point_info = points.back();
 
-  // Convert the previous point stored in points to Cartesian Trajectory Point
-  std::unique_ptr<TrajectoryPoint> prev_point = std::unique_ptr<TrajectoryPoint>(
-      new JointTrajectoryPoint(prev_point_info.positions, prev_point_info.time_from_start.toSec(), ""));
-  std::unique_ptr<CartTrajectoryPoint> prev_traj_point = prev_point->toCartTrajPoint(*this);
-  std::unique_ptr<CartTrajectoryPoint> target_point;
+  // // Convert the previous point stored in points to Cartesian Trajectory Point
+  // std::unique_ptr<TrajectoryPoint> prev_point = std::unique_ptr<TrajectoryPoint>(
+  //     new JointTrajectoryPoint(prev_point_info.positions, prev_point_info.time_from_start.toSec(), ""));
+  // std::unique_ptr<CartTrajectoryPoint> prev_traj_point = prev_point->toCartTrajPoint(*this);
+  // std::unique_ptr<CartTrajectoryPoint> target_point;
 
-  if (prev_traj_point)
-  {
-    target_point = traj_point->toCartTrajPoint(*this);
-    if (!target_point)
-    {
-      ROS_ERROR_STREAM("Failed to find FK for " << traj_point->name());
-      return false;
-    }
-  }
-  else
-  {
-    ROS_ERROR_STREAM("Failed to find FK for already added point. This is unexpected.");
-    return false;
-  }
+  // if (prev_traj_point)
+  // {
+  //   target_point = traj_point->toCartTrajPoint(*this);
+  //   if (!target_point)
+  //   {
+  //     ROS_ERROR_STREAM("Failed to find FK for " << traj_point->name());
+  //     return false;
+  //   }
+  // }
+  // else
+  // {
+  //   ROS_ERROR_STREAM("Failed to find FK for already added point. This is unexpected.");
+  //   return false;
+  // }
 
-  unsigned int points_added = 0;
-  for (std::size_t i = 1; i <= num_steps + 1; ++i)
-  {
-    double t = (double)i / (double)(num_steps + 1);
-    std::unique_ptr<CartTrajectoryPoint> new_point_cart;
-    interpolate(prev_traj_point, target_point, t, new_point_cart);
+  // unsigned int points_added = 0;
+  // for (std::size_t i = 1; i <= num_steps + 1; ++i)
+  // {
+  //   double t = (double)i / (double)(num_steps + 1);
+  //   std::unique_ptr<CartTrajectoryPoint> new_point_cart;
+  //   interpolate(prev_traj_point, target_point, t, new_point_cart);
 
-    std::unique_ptr<TrajectoryPoint> new_point =
-        std::unique_ptr<TrajectoryPoint>(new CartTrajectoryPoint(new_point_cart->pose(), new_point_cart->time(), ""));
+  //   std::unique_ptr<TrajectoryPoint> new_point =
+  //       std::unique_ptr<TrajectoryPoint>(new CartTrajectoryPoint(new_point_cart->pose(), new_point_cart->time(), ""));
 
-    // Add new point at the end of Joint Trajectory (named points_local)
-    if (jointInterpolation(new_point, points_local, (unsigned int)0, collision_check))
-    {
-      points_added++;
-      ROS_INFO_STREAM(points_added << " points among " << (num_steps + 1) << " added successfullyfor "
-                                   << traj_point->name());
-    }
-    else
-    {
-      ROS_WARN_STREAM("Conversion to joint trajectory failed at " << points_added << " among " << (num_steps + 1)
-                                                                  << "points for " << traj_point->name()
-                                                                  << ". Exiting without interpolation");
-      points_local.clear();
-      return false;
-    }
-  }
+  //   // Add new point at the end of Joint Trajectory (named points_local)
+  //   if (jointInterpolation(new_point, points_local, (unsigned int)0, collision_check))
+  //   {
+  //     points_added++;
+  //     ROS_INFO_STREAM(points_added << " points among " << (num_steps + 1) << " added successfullyfor "
+  //                                  << traj_point->name());
+  //   }
+  //   else
+  //   {
+  //     ROS_WARN_STREAM("Conversion to joint trajectory failed at " << points_added << " among " << (num_steps + 1)
+  //                                                                 << "points for " << traj_point->name()
+  //                                                                 << ". Exiting without interpolation");
+  //     points_local.clear();
+  //     return false;
+  //   }
+  // }
 
-  // Append the global points with local_points
-  points.insert(points.end(), points_local.begin() + 1, points_local.end());
-  ROS_INFO_STREAM("Appending trajectory point, size: " << points.size());
-  points_local.clear();
-  return true;
+  // // Append the global points with local_points
+  // points.insert(points.end(), points_local.begin() + 1, points_local.end());
+  // ROS_INFO_STREAM("Appending trajectory point, size: " << points.size());
+  // points_local.clear();
+  // return true;
 }
 
 void Robot::interpolate(const std::unique_ptr<JointTrajectoryPoint>& from,
@@ -1307,16 +1125,13 @@ bool Robot::isConfigChange(const std::vector<double> jp1, const std::vector<doub
 {
   // The maximum allowed change in joint value
   const double MAX_JOINT_CHANGE = 90.0 * M_PI / 180.0;
-
   // The number of joints allowed to exeed the maximum joint change.
   const int MAX_JOINT_CHANGE_COUNT = 1;
-
   if (jp1.size() != jp2.size())
   {
     ROS_ERROR_STREAM("Cannot check for config change, size mismatch");
     return true;
   }
-
   size_t j_change_count = 0;
   for (size_t ii = 0; ii < jp1.size(); ii++)
   {
@@ -1333,7 +1148,6 @@ bool Robot::isConfigChange(const std::vector<double> jp1, const std::vector<doub
       return true;
     }
   }
-
   return false;
 }
 

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -996,67 +996,6 @@ bool Robot::cartesianInterpolation(const std::unique_ptr<TrajectoryPoint>& traj_
                                    bool collision_check)
 {
   return trajectory_planner_.cartesianInterpolation(*this, traj_point, points, num_steps, collision_check);
-  // // Create a local vector for storing interpolated points and append
-  // // it with last element of global points to be used for interpolation
-  // std::vector<trajectory_msgs::JointTrajectoryPoint> points_local;
-  // points_local.clear();
-  // points_local.push_back(points.back());
-
-  // trajectory_msgs::JointTrajectoryPoint prev_point_info = points.back();
-
-  // // Convert the previous point stored in points to Cartesian Trajectory Point
-  // std::unique_ptr<TrajectoryPoint> prev_point = std::unique_ptr<TrajectoryPoint>(
-  //     new JointTrajectoryPoint(prev_point_info.positions, prev_point_info.time_from_start.toSec(), ""));
-  // std::unique_ptr<CartTrajectoryPoint> prev_traj_point = prev_point->toCartTrajPoint(*this);
-  // std::unique_ptr<CartTrajectoryPoint> target_point;
-
-  // if (prev_traj_point)
-  // {
-  //   target_point = traj_point->toCartTrajPoint(*this);
-  //   if (!target_point)
-  //   {
-  //     ROS_ERROR_STREAM("Failed to find FK for " << traj_point->name());
-  //     return false;
-  //   }
-  // }
-  // else
-  // {
-  //   ROS_ERROR_STREAM("Failed to find FK for already added point. This is unexpected.");
-  //   return false;
-  // }
-
-  // unsigned int points_added = 0;
-  // for (std::size_t i = 1; i <= num_steps + 1; ++i)
-  // {
-  //   double t = (double)i / (double)(num_steps + 1);
-  //   std::unique_ptr<CartTrajectoryPoint> new_point_cart;
-  //   interpolate(prev_traj_point, target_point, t, new_point_cart);
-
-  //   std::unique_ptr<TrajectoryPoint> new_point =
-  //       std::unique_ptr<TrajectoryPoint>(new CartTrajectoryPoint(new_point_cart->pose(), new_point_cart->time(), ""));
-
-  //   // Add new point at the end of Joint Trajectory (named points_local)
-  //   if (jointInterpolation(new_point, points_local, (unsigned int)0, collision_check))
-  //   {
-  //     points_added++;
-  //     ROS_INFO_STREAM(points_added << " points among " << (num_steps + 1) << " added successfullyfor "
-  //                                  << traj_point->name());
-  //   }
-  //   else
-  //   {
-  //     ROS_WARN_STREAM("Conversion to joint trajectory failed at " << points_added << " among " << (num_steps + 1)
-  //                                                                 << "points for " << traj_point->name()
-  //                                                                 << ". Exiting without interpolation");
-  //     points_local.clear();
-  //     return false;
-  //   }
-  // }
-
-  // // Append the global points with local_points
-  // points.insert(points.end(), points_local.begin() + 1, points_local.end());
-  // ROS_INFO_STREAM("Appending trajectory point, size: " << points.size());
-  // points_local.clear();
-  // return true;
 }
 
 void Robot::interpolate(const std::unique_ptr<JointTrajectoryPoint>& from,

--- a/moveit_simple/src/trajectory_planner.cpp
+++ b/moveit_simple/src/trajectory_planner.cpp
@@ -1,8 +1,7 @@
 /*
  * Software License Agreement (Apache License)
  *
- * Copyright (c) 2016 Shaun Edwards
- * Copyright (c) 2018 Plus One Robotics
+ * Copyright (c) 2019 Plus One Robotics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/moveit_simple/src/trajectory_planner.cpp
+++ b/moveit_simple/src/trajectory_planner.cpp
@@ -1,0 +1,323 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2016 Shaun Edwards
+ * Copyright (c) 2018 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include <moveit_simple/trajectory_planner.h>
+#include <moveit_simple/conversions.h>
+#include <moveit_simple/robot.h>
+#include <moveit_simple/joint_locker.h>
+
+namespace moveit_simple {
+
+void TrajectoryPlanner::addTrajPoint(const std::string& traj_name, std::unique_ptr<TrajectoryPoint>& point,
+                         const InterpolationType& type, const unsigned int num_steps)
+{
+  std::lock_guard<std::recursive_mutex> guard(trajectory_info_map_mutex_);
+  traj_info_map_[traj_name].push_back({ std::move(point), type, num_steps });
+}
+
+void TrajectoryPlanner::clearTrajectory(const std::string& traj_name)
+{
+  std::lock_guard<std::recursive_mutex> guard(trajectory_info_map_mutex_);
+  traj_info_map_.erase(traj_name);
+}
+
+std::vector<moveit_simple::JointTrajectoryPoint> TrajectoryPlanner::plan(Robot& robot, const std::string traj_name, bool collision_check)
+{
+  std::vector<moveit_simple::JointTrajectoryPoint> plan;
+
+  if (traj_info_map_.count(traj_name))
+  {
+    std::vector<trajectory_msgs::JointTrajectoryPoint> ROS_trajectory_points;
+
+    try
+    {
+      if (toJointTrajectory(robot, traj_name, ROS_trajectory_points, collision_check))
+      {
+        // Modify the speed of execution for the trajectory based off of the speed_modifier
+        for (std::size_t i = 0; i < ROS_trajectory_points.size(); i++)
+        {
+          ROS_trajectory_points[i].time_from_start *= (1.0 / robot.getSpeedModifier());
+        }
+
+        std::vector<moveit_simple::JointTrajectoryPoint> goal = toJointTrajectoryPoint(ROS_trajectory_points);
+
+        ROS_INFO_STREAM("Successfully planned out trajectory: [" << traj_name << "]");
+
+        return goal;
+      }
+      else
+      {
+        ROS_ERROR_STREAM("Failed to convert [" << traj_name << "] to joint trajectory");
+        throw IKFailException("Conversion to joint trajectory failed for " + traj_name);
+      }
+    }
+    catch (CollisionDetected& cd)
+    {
+      ROS_ERROR_STREAM("Collision detected in [" << traj_name << "]");
+      throw cd;
+    }
+  }
+  else
+  {
+    ROS_ERROR_STREAM("Trajectory [" << traj_name << "] not found");
+    throw std::invalid_argument("No trajectory found named " + traj_name);
+  }
+ return plan;
+}
+
+bool TrajectoryPlanner::toJointTrajectory(Robot& robot, const std::string traj_name, std::vector<trajectory_msgs::JointTrajectoryPoint>& points,
+                              bool collision_check)
+{
+  const TrajectoryInfo& traj_info = traj_info_map_[traj_name];
+
+  // The first point in any trajectory is the current pose
+  std::vector<double> current_joint_position = robot.getJointState();
+  points.clear();
+  points.push_back(toJointTrajPtMsg(current_joint_position, 0.0));
+
+  for (size_t i = 0; i < traj_info.size(); ++i)
+  {
+    const std::unique_ptr<TrajectoryPoint>& traj_point = traj_info[i].point;
+    if (traj_info[i].type == interpolation_type::JOINT)
+    {
+      if (jointInterpolation(robot, traj_point, points, traj_info[i].num_steps, collision_check))
+      {
+        ROS_INFO_STREAM("Trajectory successfully added till " << traj_point->name());
+      }
+      else
+      {
+        ROS_ERROR_STREAM("Conversion to joint trajectory failed for " << traj_name << " due to IK failure of "
+                                                                      << traj_point->name());
+        return false;
+      }
+    }
+    else if (traj_info[i].type == interpolation_type::CARTESIAN)
+    {
+      if (robot.cartesianInterpolation(traj_point, points, traj_info[i].num_steps, collision_check))
+      {
+        ROS_INFO_STREAM("Trajectory successfully added till " << traj_point->name());
+      }
+      else
+      {
+        ROS_ERROR_STREAM("Conversion to joint trajectory failed for " << traj_name << " before adding "
+                                                                      << traj_point->name());
+        return false;
+      }
+    }
+    else
+    {
+      ROS_ERROR_STREAM("Unknown interpolation call " << traj_info[i].type);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool TrajectoryPlanner::jointInterpolation(Robot& robot, const std::unique_ptr<TrajectoryPoint>& traj_point,
+                               std::vector<trajectory_msgs::JointTrajectoryPoint>& points, unsigned int num_steps,
+                               bool collision_check)
+{
+  const double IK_TIMEOUT = 0.250;  // 250 ms for IK solving
+
+  auto options = traj_point->getJointLockOptions();
+
+  // Check to make sure the points vector is not empty. At minimum, it should plan from the current state.
+  if (!points.size())
+  {
+    ROS_ERROR_STREAM("jointInterpolation was given an invalid value for `points`. This vector may not be empty");
+    return false;
+  }
+
+  // Get the last point in the points trajectory to connect it to this new trajectory
+  trajectory_msgs::JointTrajectoryPoint prev_point_info = points.back();
+  std::vector<double> prev_point = prev_point_info.positions;
+  double prev_time = prev_point_info.time_from_start.toSec();
+
+  // Convert the previous point stored in points to Joint Trajectory Point
+  std::unique_ptr<JointTrajectoryPoint> prev_traj_point =
+      std::unique_ptr<JointTrajectoryPoint>(new JointTrajectoryPoint(prev_point, prev_time, ""));
+
+  std::unique_ptr<JointTrajectoryPoint> target_point;
+  if (traj_point->type() != TrajectoryPoint::JOINT)
+  {
+    const size_t MAX_IK_ATTEMPTS = 2;
+    size_t num_attempts = 0;
+
+    while (true)
+    {
+      num_attempts++;
+      target_point = traj_point->toJointTrajPoint(robot, IK_TIMEOUT, prev_point);
+
+      if (target_point)
+      {
+        if (robot.isConfigChange(prev_point, target_point->jointPoint()))
+        {
+          ROS_WARN_STREAM("Configuration change detected in move to/from joint state: ("
+                          << traj_point->name() << "), of type: " << traj_point->type() << " to joint trajectory");
+        }
+        else
+        {
+          ROS_INFO_STREAM("Found proper IK (no config change) in " << num_attempts << " attempts");
+          break;
+        }
+      }
+      else
+      {
+        ROS_WARN_STREAM("Failed to convert trajectory point:  ("
+                        << traj_point->name() << "), of type: " << traj_point->type() << " to joint trajectory");
+        return false;
+      }
+      if (num_attempts >= MAX_IK_ATTEMPTS)
+      {
+        ROS_ERROR_STREAM("Failed to find proper IK (no config change) in " << num_attempts << " attempts");
+        return false;
+      }
+    }
+  }
+  else
+  {
+    target_point = traj_point->toJointTrajPoint(robot, IK_TIMEOUT, prev_point);
+    if (!target_point)
+    {
+      ROS_WARN_STREAM("Failed to convert joint point - this shouldn't happen");
+      return false;
+    }
+  }
+
+  // Create a local vector for storing interpolated points
+  std::vector<trajectory_msgs::JointTrajectoryPoint> points_local;
+  unsigned int points_added = 0;
+  // TODO (mlautman): Explain why we are adding num_steps + 1 instead of just num_steps.
+  for (std::size_t i = 1; i <= num_steps + 1; ++i)
+  {
+    double t = (double)i / (double)(num_steps + 1);
+    std::unique_ptr<JointTrajectoryPoint> new_point;
+    robot.interpolate(prev_traj_point, target_point, t, new_point);
+    if (new_point)
+    {
+      if ((collision_check) && (robot.isInCollision(new_point->jointPoint())))
+      {
+        ROS_WARN_STREAM("Collision detected at " << points_added << " among " << (num_steps + 1) << " points for "
+                                                 << traj_point->name());
+        // TODO (mlautman): preserve points_local for debugging
+        points_local.clear();
+        throw CollisionDetected("Collision detected while interpolating " + traj_point->name());
+      }
+      else
+      {
+        // Lock the joints
+        auto new_point_joints = new_point->jointPoint();
+        JointLocker::lockJoints(prev_point, new_point_joints, options);
+        auto locked_new_point =
+            std::unique_ptr<JointTrajectoryPoint>(new JointTrajectoryPoint(new_point_joints, new_point->time(), ""));
+
+        points_local.push_back(toJointTrajPtMsg(*locked_new_point));
+        points_added++;
+        ROS_INFO_STREAM(points_added << " points among " << (num_steps + 1) << " successfully interpolated for "
+                                     << traj_point->name());
+      }
+    }
+    else
+    {
+      ROS_WARN_STREAM("Conversion to joint trajectory failed at " << points_added << " among " << (num_steps + 1)
+                                                                  << "points for " << traj_point->name()
+                                                                  << ". Exiting without interpolation");
+      points_local.clear();
+      return false;
+    }
+  }
+  // Append the global points with local_points
+  points.insert(points.end(), points_local.begin(), points_local.end());
+  ROS_INFO_STREAM("Appending trajectory point, size: " << points.size());
+  points_local.clear();
+  return true;
+}
+
+bool TrajectoryPlanner::cartesianInterpolation(Robot& robot,
+                                   const std::unique_ptr<TrajectoryPoint>& traj_point,
+                                   std::vector<trajectory_msgs::JointTrajectoryPoint>& points, unsigned int num_steps,
+                                   bool collision_check)
+{
+  // Create a local vector for storing interpolated points and append
+  // it with last element of global points to be used for interpolation
+  std::vector<trajectory_msgs::JointTrajectoryPoint> points_local;
+  points_local.clear();
+  points_local.push_back(points.back());
+
+  trajectory_msgs::JointTrajectoryPoint prev_point_info = points.back();
+
+  // Convert the previous point stored in points to Cartesian Trajectory Point
+  std::unique_ptr<TrajectoryPoint> prev_point = std::unique_ptr<TrajectoryPoint>(
+      new JointTrajectoryPoint(prev_point_info.positions, prev_point_info.time_from_start.toSec(), ""));
+  std::unique_ptr<CartTrajectoryPoint> prev_traj_point = prev_point->toCartTrajPoint(robot);
+  std::unique_ptr<CartTrajectoryPoint> target_point;
+
+  if (prev_traj_point)
+  {
+    target_point = traj_point->toCartTrajPoint(robot);
+    if (!target_point)
+    {
+      ROS_ERROR_STREAM("Failed to find FK for " << traj_point->name());
+      return false;
+    }
+  }
+  else
+  {
+    ROS_ERROR_STREAM("Failed to find FK for already added point. This is unexpected.");
+    return false;
+  }
+
+  unsigned int points_added = 0;
+  for (std::size_t i = 1; i <= num_steps + 1; ++i)
+  {
+    double t = (double)i / (double)(num_steps + 1);
+    std::unique_ptr<CartTrajectoryPoint> new_point_cart;
+    robot.interpolate(prev_traj_point, target_point, t, new_point_cart);
+
+    std::unique_ptr<TrajectoryPoint> new_point =
+        std::unique_ptr<TrajectoryPoint>(new CartTrajectoryPoint(new_point_cart->pose(), new_point_cart->time(), ""));
+
+    // Add new point at the end of Joint Trajectory (named points_local)
+    if (jointInterpolation(robot, new_point, points_local, (unsigned int)0, collision_check))
+    {
+      points_added++;
+      ROS_INFO_STREAM(points_added << " points among " << (num_steps + 1) << " added successfullyfor "
+                                   << traj_point->name());
+    }
+    else
+    {
+      ROS_WARN_STREAM("Conversion to joint trajectory failed at " << points_added << " among " << (num_steps + 1)
+                                                                  << "points for " << traj_point->name()
+                                                                  << ". Exiting without interpolation");
+      points_local.clear();
+      return false;
+    }
+  }
+
+  // Append the global points with local_points
+  points.insert(points.end(), points_local.begin() + 1, points_local.end());
+  ROS_INFO_STREAM("Appending trajectory point, size: " << points.size());
+  points_local.clear();
+  return true;
+}
+
+
+} // namespace moveit_simple


### PR DESCRIPTION
This separates the trajectory planning capabilities into it's own class. This accomplishes a few things. It reduces the size of the robot class to make it more manageable and sets the stage for a Descartes integration without adding a dependency to the main project. 

There are more methods that we could refactor out of the robot class and into the trajectory planner, but in an effort to keep this PR small, make as few API changes as possible and open the door for early feedback we think that this PR is ready for review as is.

This PR includes  #81, #83, #84,  and #85 which should be removed from this PR before merging