### PR TITLE
Trajectory validation and retiming waypoints

### DIFF
--- a/moveit_simple/include/moveit_simple/exceptions.h
+++ b/moveit_simple/include/moveit_simple/exceptions.h
@@ -96,5 +96,20 @@ public:
   JointSeedException(const std::string error_description)
     : std::runtime_error(error_description) { }
 };
+
+/**
+ * @brief InvalidTrajectoryException
+ *
+ * This inherits from std::runtime_error.
+ * This is an exception class to be thrown when a trajectory
+ * contains invalid waypoints, i.e. joint states are out of
+ * bounds or time stamps are not achievable.
+ */
+class InvalidTrajectoryException : public std::runtime_error
+{
+public:
+  InvalidTrajectoryException(const std::string error_description)
+    : std::runtime_error(error_description) { }
+};
 } // namespace moveit_simple
 #endif // EXCEPTIONS_H

--- a/moveit_simple/include/moveit_simple/online_robot.h
+++ b/moveit_simple/include/moveit_simple/online_robot.h
@@ -59,23 +59,26 @@ public:
    * @param traj_name - name of trajectory to be executed (must be filled with
    * prior calls to "addTrajPoint".
    * @param collision_check - bool to turn check for collision on\off
+   * @param fix_trajectory - bool to fix trajectory timesteps if necessary on\off
    * @throws <moveit_simple::ExecutionFailureException> (Execution failure)
    * @throws <moveit_simple::IKFailException> (Conversion to joint trajectory failed)
    * @throws <std::invalid_argument> (Trajectory "traj_name" not found)
    * @throws <moveit_simple::CollisionDetected> (One of interpolated point is
    * in Collision with itself or environment)
    */
-  void execute(const std::string traj_name, bool collision_check = false);
+  void execute(const std::string traj_name, bool collision_check = false, bool fix_trajectory = false);
 
   /**
    * @brief execute a given planned joint trajectory
    * @param goal - Joint Trajectory goal which is a known 'Plan'
    * @param collision_check - bool to turn check for collision on\off
+   * @param fix_trajectory - bool to fix trajectory timesteps if necessary on\off
    * @throws <moveit_simple::ExecutionFailureException> (Execution failure)
    * @throws <moveit_simple::CollisionDetected> (One of interpolated point is
    * in Collision with itself or environment)
    */
-  void execute(std::vector<moveit_simple::JointTrajectoryPoint> &goal, bool collision_check = false);
+  void execute(std::vector<moveit_simple::JointTrajectoryPoint> &goal, bool collision_check = false,
+               bool fix_trajectory = false);
 
   /**
    * @brief Starts execution for a given trajectory, non blocking

--- a/moveit_simple/include/moveit_simple/online_robot.h
+++ b/moveit_simple/include/moveit_simple/online_robot.h
@@ -59,26 +59,26 @@ public:
    * @param traj_name - name of trajectory to be executed (must be filled with
    * prior calls to "addTrajPoint".
    * @param collision_check - bool to turn check for collision on\off
-   * @param fix_trajectory - bool to fix trajectory timesteps if necessary on\off
+   * @param retime_trajectory - bool to fix trajectory timesteps if necessary on\off
    * @throws <moveit_simple::ExecutionFailureException> (Execution failure)
    * @throws <moveit_simple::IKFailException> (Conversion to joint trajectory failed)
    * @throws <std::invalid_argument> (Trajectory "traj_name" not found)
    * @throws <moveit_simple::CollisionDetected> (One of interpolated point is
    * in Collision with itself or environment)
    */
-  void execute(const std::string traj_name, bool collision_check = false, bool fix_trajectory = false);
+  void execute(const std::string traj_name, bool collision_check = false, bool retime_trajectory = false);
 
   /**
    * @brief execute a given planned joint trajectory
    * @param goal - Joint Trajectory goal which is a known 'Plan'
    * @param collision_check - bool to turn check for collision on\off
-   * @param fix_trajectory - bool to fix trajectory timesteps if necessary on\off
+   * @param retime_trajectory - bool to fix trajectory timesteps if necessary on\off
    * @throws <moveit_simple::ExecutionFailureException> (Execution failure)
    * @throws <moveit_simple::CollisionDetected> (One of interpolated point is
    * in Collision with itself or environment)
    */
   void execute(std::vector<moveit_simple::JointTrajectoryPoint> &goal, bool collision_check = false,
-               bool fix_trajectory = false);
+               bool retime_trajectory = false);
 
   /**
    * @brief Starts execution for a given trajectory, non blocking

--- a/moveit_simple/include/moveit_simple/trajectory_processing.h
+++ b/moveit_simple/include/moveit_simple/trajectory_processing.h
@@ -54,37 +54,44 @@ TrajectoryValidationResult validateTrajectory(robot_model::RobotModelConstPtr ro
       if (bounds.position_bounded_ && !joint_model->satisfiesPositionBounds(&point.positions[j]))
       {
         result.value = TrajectoryValidationResult::InvalidPosition;
-        result.error_message = "Trajectory contains waypoints that don't satisfy position bounds";
+        result.error_message = "Trajectory invalidates position bounds in waypoint " + std::to_string(i) + " and joint "
+          + std::to_string(j);
         return result;
       }
       // validate velocity/acceleration bounds and pair-wise time difference
       double dt = (point.time_from_start - previous_point.time_from_start).toSec();
       if (bounds.velocity_bounded_)
       {
-        result.value = TrajectoryValidationResult::InvalidVelocity;
         if (bounds.max_velocity_ < std::abs(point.velocities[j]))
         {
-          result.error_message = "Trajectory waypoint does not satisfy velocity bounds";
+          result.value = TrajectoryValidationResult::InvalidVelocity;
+          result.error_message = "Trajectory invalidates velocity bounds in waypoint " + std::to_string(i)
+            + " and joint " + std::to_string(j);
           return result;
         }
         if (i > 0 && bounds.max_velocity_ * dt < std::abs(point.positions[j] - previous_point.positions[j]))
         {
-          result.error_message = "Trajectory waypoint position not reachable within target time and velocity limits";
+          result.value = TrajectoryValidationResult::InvalidVelocity;
+          result.error_message = "Position of trajectory waypoint " + std::to_string(i)
+            + " is not reachable given target time and velocity limits";
           return result;
         }
       }
       // validate acceleration bounds and pair-wise velocty difference
       if (bounds.acceleration_bounded_)
       {
-        result.value = TrajectoryValidationResult::InvalidAcceleration;
         if (bounds.max_acceleration_ < std::abs(point.accelerations[j]))
         {
-          result.error_message = "Trajectory waypoint does not satisfy acceleration bounds";
+          result.value = TrajectoryValidationResult::InvalidAcceleration;
+          result.error_message = "Trajectory invalidates acceleration bounds in waypoint " + std::to_string(i)
+            + " and joint " + std::to_string(j);
           return result;
         }
         if (i > 0 && bounds.max_acceleration_ * dt < std::abs(point.velocities[j] - previous_point.velocities[j]))
         {
-          result.error_message = "Trajectory waypoint velocity not reachable within target time and acceleration limits";
+          result.value = TrajectoryValidationResult::InvalidAcceleration;
+          result.error_message = "Velocity of trajectory waypoint " + std::to_string(i) + " and joint "
+            + std::to_string(j) + " is not reachable given target time and acceleration limit";
           return result;
         }
       }

--- a/moveit_simple/include/moveit_simple/trajectory_processing.h
+++ b/moveit_simple/include/moveit_simple/trajectory_processing.h
@@ -98,7 +98,7 @@ bool fixTrajectory(robot_model::RobotModelConstPtr robot_model, const trajectory
   return true;
 }
 
-bool validateTrajectory(robot_model::RobotModelConstPtr robot_model,
+void validateTrajectory(robot_model::RobotModelConstPtr robot_model,
                         const trajectory_msgs::JointTrajectory& trajectory,
                         bool fix_trajectory)
 {

--- a/moveit_simple/include/moveit_simple/trajectory_processing.h
+++ b/moveit_simple/include/moveit_simple/trajectory_processing.h
@@ -102,8 +102,8 @@ TrajectoryValidationResult validateTrajectory(robot_model::RobotModelConstPtr ro
   return result;
 }
 
-void fixTrajectory(robot_model::RobotModelConstPtr robot_model, const std::string& group_name,
-                   trajectory_msgs::JointTrajectory& joint_trajectory)
+void retimeTrajectory(robot_model::RobotModelConstPtr robot_model, const std::string& group_name,
+                      trajectory_msgs::JointTrajectory& joint_trajectory)
 {
   // convert trajectory message to robot trajectory
   robot_trajectory::RobotTrajectory trajectory(robot_model, group_name);
@@ -120,14 +120,14 @@ void fixTrajectory(robot_model::RobotModelConstPtr robot_model, const std::strin
 void validateTrajectory(robot_model::RobotModelConstPtr robot_model,
                         const std::string& group_name,
                         trajectory_msgs::JointTrajectory& trajectory,
-                        bool fix_trajectory)
+                        bool retime_trajectory)
 {
   TrajectoryValidationResult result = validateTrajectory(robot_model, trajectory);
   if (result.value != TrajectoryValidationResult::Success)
   {
     // we can't fix invalid positions by trajectory parameterization
-    if (fix_trajectory && result.value != TrajectoryValidationResult::InvalidPosition)
-      fixTrajectory(robot_model, group_name, trajectory);
+    if (retime_trajectory && result.value != TrajectoryValidationResult::InvalidPosition)
+      retimeTrajectory(robot_model, group_name, trajectory);
     else
       throw InvalidTrajectoryException(result.error_message);
   }

--- a/moveit_simple/include/moveit_simple/trajectory_processing.h
+++ b/moveit_simple/include/moveit_simple/trajectory_processing.h
@@ -1,0 +1,117 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2019 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <moveit_simple/exceptions.h>
+
+#ifndef TRAJECTORY_PROCESSING_H
+#define TRAJECTORY_PROCESSING_H
+namespace moveit_simple
+{
+namespace trajectory_processing
+{
+struct TrajectoryValidationResult
+{
+  enum { Success,
+         InvalidPosition,
+         InvalidVelocity,
+         InvalidAcceleration,
+         InvalidTimestamp} value;
+  std::string error_message;
+};
+TrajectoryValidationResult validateTrajectory(robot_model::RobotModelConstPtr robot_model,
+                                              const trajectory_msgs::JointTrajectory& trajectory)
+{
+  TrajectoryValidationResult result;
+  const std::vector<std::string>& joint_names = trajectory.joint_names;
+  trajectory_msgs::JointTrajectoryPoint previous_point;
+  for (size_t i = 0; i < trajectory.points.size(); ++i)
+  {
+    // validate waypoint bounds
+    const auto& point = trajectory.points[i];
+    for (size_t j = 0; j < joint_names.size(); ++j)
+    {
+      const auto& joint_model = robot_model->getJointModel(joint_names[j]);
+      const auto& bounds = joint_model->getVariableBounds()[0];
+      // validate position bounds and throw exception since this can't be fixed easily
+      if (bounds.position_bounded_ && !joint_model->satisfiesPositionBounds(&point.positions[j]))
+      {
+        result.value = TrajectoryValidationResult::InvalidPosition;
+        result.error_message = "Trajectory contains waypoints that don't satisfy position bounds";
+        return result;
+      }
+      // validate velocity/acceleration bounds and pair-wise time difference
+      double dt = (point.time_from_start - previous_point.time_from_start).toSec();
+      if (bounds.velocity_bounded_)
+      {
+        result.value = TrajectoryValidationResult::InvalidVelocity;
+        if (bounds.max_velocity_ < std::abs(point.velocities[j]))
+        {
+          result.error_message = "Trajectory waypoint does not satisfy velocity bounds";
+          return result;
+        }
+        if (i > 0 && bounds.max_velocity_ * dt < std::abs(point.positions[j] - previous_point.positions[j]))
+        {
+          result.error_message = "Trajectory waypoint position not reachable within target time and velocity limits";
+          return result;
+        }
+      }
+      // validate acceleration bounds and pair-wise velocty difference
+      if (bounds.acceleration_bounded_)
+      {
+        result.value = TrajectoryValidationResult::InvalidAcceleration;
+        if (bounds.max_acceleration_ < std::abs(point.accelerations[j]))
+        {
+          result.error_message = "Trajectory waypoint does not satisfy acceleration bounds";
+          return result;
+        }
+        if (i > 0 && bounds.max_acceleration_ * dt < std::abs(point.velocities[j] - previous_point.velocities[j]))
+        {
+          result.error_message = "Trajectory waypoint velocity not reachable within target time and acceleration limits";
+          return result;
+        }
+      }
+    }
+    previous_point = point;
+  }
+  result.value = TrajectoryValidationResult::Success;
+  return result;
+}
+
+bool fixTrajectory(robot_model::RobotModelConstPtr robot_model, const trajectory_msgs::JointTrajectory& trajectory)
+{
+  // TODO(henningkayser): compute timestamps
+  return true;
+}
+
+bool validateTrajectory(robot_model::RobotModelConstPtr robot_model,
+                        const trajectory_msgs::JointTrajectory& trajectory,
+                        bool fix_trajectory)
+{
+  TrajectoryValidationResult result = validateTrajectory(robot_model, trajectory);
+  if (result.value != TrajectoryValidationResult::Success)
+  {
+    // we can't fix invalid positions by trajectory parameterization
+    if (fix_trajectory && result.value != TrajectoryValidationResult::InvalidPosition)
+      fixTrajectory(robot_model, trajectory);
+    else
+      throw InvalidTrajectoryException(result.error_message);
+  }
+}
+}  // namespace trajectory_processing
+}  // namespace moveit_simple
+#endif  // TRAJECTORY_PROCESSING_H

--- a/moveit_simple/src/online_robot.cpp
+++ b/moveit_simple/src/online_robot.cpp
@@ -126,7 +126,7 @@ void OnlineRobot::execute(std::vector<moveit_simple::JointTrajectoryPoint> &join
 
   // validate trajectory waypoint bounds and timestamps
   // if invalid, attempt to fix it or throw InvalidTrajectoryException
-  trajectory_processing::validateTrajectory(robot_model_ptr_, goal.trajectory, fix_trajectory);
+  trajectory_processing::validateTrajectory(robot_model_ptr_, joint_group_->getName(), goal.trajectory, fix_trajectory);
 
   int collision_points = trajCollisionCheck(goal, collision_check);
 

--- a/moveit_simple/src/online_robot.cpp
+++ b/moveit_simple/src/online_robot.cpp
@@ -77,7 +77,7 @@ OnlineRobot::OnlineRobot(const ros::NodeHandle &nh, const std::string &robot_des
   }
 }
 
-void OnlineRobot::execute(const std::string traj_name, bool collision_check, bool fix_trajectory)
+void OnlineRobot::execute(const std::string traj_name, bool collision_check, bool retime_trajectory)
 {
   std::lock_guard<std::recursive_mutex> guard(m_);
 
@@ -86,7 +86,7 @@ void OnlineRobot::execute(const std::string traj_name, bool collision_check, boo
     std::vector<moveit_simple::JointTrajectoryPoint> goal;
 
     goal = plan(traj_name, collision_check);
-    execute(goal, false, fix_trajectory);
+    execute(goal, false, retime_trajectory);
   }
   catch (IKFailException &ik)
   {
@@ -116,7 +116,7 @@ void OnlineRobot::execute(const std::string traj_name, bool collision_check, boo
 }
 
 void OnlineRobot::execute(std::vector<moveit_simple::JointTrajectoryPoint> &joint_trajectory_points,
-                          bool collision_check, bool fix_trajectory)
+                          bool collision_check, bool retime_trajectory)
 {
   std::lock_guard<std::recursive_mutex> guard(m_);
 
@@ -126,7 +126,7 @@ void OnlineRobot::execute(std::vector<moveit_simple::JointTrajectoryPoint> &join
 
   // validate trajectory waypoint bounds and timestamps
   // if invalid, attempt to fix it or throw InvalidTrajectoryException
-  trajectory_processing::validateTrajectory(robot_model_ptr_, joint_group_->getName(), goal.trajectory, fix_trajectory);
+  trajectory_processing::validateTrajectory(robot_model_ptr_, joint_group_->getName(), goal.trajectory, retime_trajectory);
 
   int collision_points = trajCollisionCheck(goal, collision_check);
 

--- a/moveit_simple/test/kuka_kr210.cpp
+++ b/moveit_simple/test/kuka_kr210.cpp
@@ -446,11 +446,11 @@ TEST_F(UserRobotTest, speed_reconfiguration)
   double execution_time_check_2 = INT_MAX;
   double execution_time_check_3 = INT_MAX;
 
-  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "home",      0.5));
-  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint1", 1.0));
-  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "tf_pub1",   2.0));
-  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint2", 3.0));
-  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint3", 4.0));
+  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "home",      1.0));
+  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint1", 2.0));
+  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "tf_pub1",   3.0));
+  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint2", 4.0));
+  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint3", 5.0));
 
   // Test 1 -- Max_Execution_Speed: Plan & then Execute that Plan separately
   robot->setSpeedModifier(1.0);

--- a/moveit_simple/test/kuka_kr210.cpp
+++ b/moveit_simple/test/kuka_kr210.cpp
@@ -698,13 +698,17 @@ TEST_F(DeveloperRobotTest, collision)
   const moveit_simple::InterpolationType cart = moveit_simple::interpolation_type::CARTESIAN;
   const moveit_simple::InterpolationType joint = moveit_simple::interpolation_type::JOINT;
 
+  // joint1, joint2 are collision free but interpolated joint3 is in collision
   std::vector<trajectory_msgs::JointTrajectoryPoint> points;
-
   std::vector<double>joint1(6,0);
+  joint1[1] = 0.77;
+  joint1[2] = 1.13;
   std::vector<double>joint2(6,0);
+  joint2[1] = 1.45;
+  joint2[2] = 0.89;
   std::vector<double>joint3(6,0);
-  joint2[2] = M_PI;
-  joint3[2] = M_PI/2;
+  joint3[1] = (joint1[1] + joint2[1]) / 2;
+  joint3[2] = (joint1[2] + joint2[2]) / 2;
   std::unique_ptr<moveit_simple::TrajectoryPoint> joint_point1 =
      std::unique_ptr<moveit_simple::TrajectoryPoint>
      (new moveit_simple::JointTrajectoryPoint(joint1, 1.0, "joint_point1"));

--- a/moveit_simple/test/kuka_kr210.cpp
+++ b/moveit_simple/test/kuka_kr210.cpp
@@ -158,7 +158,7 @@ TEST_F(UserRobotTest, validate_trajectory)
   EXPECT_NO_THROW(robot->execute(TRAJECTORY_NAME));
 
   // go back to home in no time, should fail
-  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "home",      0.0));
+  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint2",      0.0));
   EXPECT_THROW(robot->execute(TRAJECTORY_NAME), moveit_simple::InvalidTrajectoryException);
 
   // fixing the trajectory should work

--- a/moveit_simple/test/kuka_kr210.cpp
+++ b/moveit_simple/test/kuka_kr210.cpp
@@ -146,6 +146,25 @@ TEST_F(UserRobotTest, add_trajectory)
   EXPECT_THROW(robot->execute("bad_traj"), std::invalid_argument);
 }
 
+TEST_F(UserRobotTest, validate_trajectory)
+{
+  ROS_INFO_STREAM("Testing trajectory validation");
+  const std::string TRAJECTORY_NAME("val_traj");
+  const moveit_simple::InterpolationType joint = moveit_simple::interpolation_type::JOINT;
+
+  // try valid trajectory
+  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "home",      0.5));
+  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "waypoint1", 1.0, joint, 5));
+  EXPECT_NO_THROW(robot->execute(TRAJECTORY_NAME));
+
+  // go back to home in no time, should fail
+  EXPECT_NO_THROW(robot->addTrajPoint(TRAJECTORY_NAME, "home",      0.0));
+  EXPECT_THROW(robot->execute(TRAJECTORY_NAME), moveit_simple::InvalidTrajectoryException);
+
+  // fixing the trajectory should work
+  ROS_INFO_STREAM("Attempting to fix the trajectory");
+  EXPECT_NO_THROW(robot->execute(TRAJECTORY_NAME, false, true));
+}
 
 TEST_F(DeveloperRobotTest, planning)
 {

--- a/moveit_simple/test/motoman_mh5.cpp
+++ b/moveit_simple/test/motoman_mh5.cpp
@@ -767,18 +767,18 @@ TEST_F(UserRobotTest, copy_current_pose)
 
   // Before the first execution robot should be at position "home"
   before_execution_1 = user_robot->getJointState();
-  EXPECT_NO_THROW(user_robot->execute(TRAJECTORY_NAME));
+  EXPECT_NO_THROW(user_robot->execute(TRAJECTORY_NAME, false, true));
   ros::Duration(0.5).sleep();
 
   // Second Execution
   // Robot should be at "wp3" at all checkpoints from here on out.
   before_execution_2 = user_robot->getJointState();
-  EXPECT_NO_THROW(user_robot->execute(TRAJECTORY_NAME));
+  EXPECT_NO_THROW(user_robot->execute(TRAJECTORY_NAME, false, true));
   ros::Duration(0.5).sleep();
 
   // Third Execution
   before_execution_3 = user_robot->getJointState();
-  EXPECT_NO_THROW(user_robot->execute(TRAJECTORY_NAME));
+  EXPECT_NO_THROW(user_robot->execute(TRAJECTORY_NAME, false, true));
   ros::Duration(0.5).sleep();
 
   // Final Position
@@ -805,11 +805,13 @@ TEST_F(DeveloperRobotTest, collision)
   std::vector<trajectory_msgs::JointTrajectoryPoint> points;
 
   std::vector<double>joint1(6,0);
+  joint1[1] = 2.61;
   std::vector<double>joint2(6,0);
+  joint2[1] = 2.61;
+  joint2[3] = M_PI / 2;
   std::vector<double>joint3(6,0);
-
-  joint2[1] = M_PI;
-  joint3[3] = -M_PI/2;
+  joint3[1] = 2.61;
+  joint3[3] = M_PI / 4;
 
   std::unique_ptr<moveit_simple::TrajectoryPoint> joint_point1 =
      std::unique_ptr<moveit_simple::TrajectoryPoint>
@@ -831,8 +833,8 @@ TEST_F(DeveloperRobotTest, collision)
   EXPECT_NO_THROW(developer_robot->execute(TRAJECTORY_NAME));
   EXPECT_FALSE(developer_robot->isInCollision(joint1));
 
-  EXPECT_TRUE(developer_robot->isInCollision(joint2));
-  EXPECT_FALSE(developer_robot->isInCollision(joint3));
+  EXPECT_FALSE(developer_robot->isInCollision(joint2));
+  EXPECT_TRUE(developer_robot->isInCollision(joint3));
   EXPECT_THROW(developer_robot->execute(TRAJECTORY_NAME, true), moveit_simple::CollisionDetected);
 
   // Test to see if above collision detection works when you separate out plan(...) & execute(...)

--- a/moveit_simple/test/motoman_mh5.cpp
+++ b/moveit_simple/test/motoman_mh5.cpp
@@ -268,7 +268,7 @@ TEST_F(UserRobotTest, validate_trajectory)
   EXPECT_NO_THROW(user_robot->execute(TRAJECTORY_NAME));
 
   // go back to home in no time, should fail
-  EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "home",      0.0));
+  EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "wp2",      0.0));
   EXPECT_THROW(user_robot->execute(TRAJECTORY_NAME), moveit_simple::InvalidTrajectoryException);
 
   // fixing the trajectory should work

--- a/moveit_simple/test/motoman_mh5.cpp
+++ b/moveit_simple/test/motoman_mh5.cpp
@@ -256,6 +256,26 @@ TEST_F(UserRobotTest, add_trajectory)
   EXPECT_THROW(user_robot->execute("bad_traj"), std::invalid_argument);
 }
 
+TEST_F(UserRobotTest, validate_trajectory)
+{
+  ROS_INFO_STREAM("Testing trajectory validation");
+  const std::string TRAJECTORY_NAME("val_traj");
+  const moveit_simple::InterpolationType joint = moveit_simple::interpolation_type::JOINT;
+
+  // try valid trajectory
+  EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "home",      0.5));
+  EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "wp1", 1.0, joint, 5));
+  EXPECT_NO_THROW(user_robot->execute(TRAJECTORY_NAME));
+
+  // go back to home in no time, should fail
+  EXPECT_NO_THROW(user_robot->addTrajPoint(TRAJECTORY_NAME, "home",      0.0));
+  EXPECT_THROW(user_robot->execute(TRAJECTORY_NAME), moveit_simple::InvalidTrajectoryException);
+
+  // fixing the trajectory should work
+  ROS_INFO_STREAM("Attempting to fix the trajectory");
+  EXPECT_NO_THROW(user_robot->execute(TRAJECTORY_NAME, false, true));
+}
+
 TEST_F(DeveloperRobotTest, planning)
 {
   const double ALLOWED_ERROR = 1e-2;


### PR DESCRIPTION
This effort adds a check to the execute() function to validate all waypoints are reachable within the given time stamps and all values are within bounds. In case a trajectory is invalid an InvalidTrajectoryExecution is thrown. An optional parameter fix_trajectory should allow reparameterizing invalid trajectories.