### PR TITLE
Limit joint windup for single IK solutions

### DIFF
--- a/moveit_simple/CMakeLists.txt
+++ b/moveit_simple/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_ros_planning
   moveit_simple_msgs
   moveit_visual_tools
+  random_numbers
   roscpp
   rosparam_handler
   sensor_msgs
@@ -38,6 +39,7 @@ catkin_package(
     eigen_conversions
     geometry_msgs
     moveit_simple_msgs
+    random_numbers
     roscpp
     rosparam_handler
     sensor_msgs
@@ -99,6 +101,10 @@ if(CATKIN_ENABLE_TESTING)
   set(MOVEIT_SIMPLE_TEST_SRC_FILES test/moveit_simple_utest.cpp test/joint_locker.cpp test/joint_lock_options.cpp)
   catkin_add_gtest(moveit_simple_utest ${MOVEIT_SIMPLE_TEST_SRC_FILES})
   target_link_libraries(moveit_simple_utest ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+  set(TOOL_WINDUP_SRC_FILES test/tool_windup_utest.cpp test/tool_windup.cpp)
+  add_rostest_gtest(tool_windup_utest test/launch/tool_windup_utest.launch ${TOOL_WINDUP_SRC_FILES})
+  target_link_libraries(tool_windup_utest ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 endif()
 

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -435,6 +435,12 @@ public:
    */
   double getSpeedModifier(void) const;
 
+  void limitJointWindup(bool enabled);
+
+  bool setIKSeedStateFractions(const std::map<size_t, double>& ik_seed_state_fractions);
+
+  std::map<size_t, double> getIKSeedStateFractions() const;
+
   void updateRvizRobotState(const Eigen::Isometry3d &pose, const std::string &in_frame,
     const std::string &joint_seed, double timeout = 10.0) const;
 
@@ -557,10 +563,10 @@ protected:
   virtual std::vector<double> getJointState(void) const;
 
   bool getIK(const Eigen::Isometry3d pose, const std::vector<double> &seed,
-    std::vector<double> &joint_point, double timeout = 1) const;
+    std::vector<double> &joint_point, double timeout = 1, bool limit_joint_windup = false) const;
 
   bool getIK(const Eigen::Isometry3d pose, std::vector<double> &joint_point,
-    double timeout = 1) const;
+    double timeout = 1, bool limit_joint_windup = false) const;
 
   bool getFK(const std::vector<double> &joint_point, Eigen::Isometry3d &pose) const;
 
@@ -613,6 +619,10 @@ protected:
 
   std::string planning_group_;
   std::string robot_description_;
+
+  // Limit IK joint windup
+  bool limit_joint_windup_;
+  std::map<size_t, double> ik_seed_state_fractions_;
 };
 } // namespace moveit_simple
 #endif // ROBOT_H

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -641,7 +641,7 @@ protected:
   std::string robot_description_;
 
   // Limit IK joint windup
-  bool limit_joint_windup_;
+  bool limit_joint_windup_ = false;
   std::map<size_t, double> ik_seed_state_fractions_;
 };
 } // namespace moveit_simple

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -435,10 +435,30 @@ public:
    */
   double getSpeedModifier(void) const;
 
+  /**
+   * @brief limitJointWindup - Enable/Disable joint windup reduction in IK solutions by
+   * applying the seed state modifiers defined in ik_seed_state_fractions_. The fraction values
+   * are multiplied with the corresponding joint values in the seed state which causes IK solutions
+   * to be "pulled" towards the center. Additionally the modified joints are solved with a lower
+   * consistency_limit of PI. Both measures in combination act as a "soft" joint limit which doesn't
+   * affect the actual freedom of the joint but only centers IK solutions by a specified amount.
+   * @param enabled - Set joint windup limitation feature on/off
+   */
   void limitJointWindup(bool enabled);
 
+  /**
+   * @brief setIKSeedStateFractions - Specify joint value modifiers that should be applied in IK
+   * calls if joint windup limitation is enabled. On how to enable and use this feature see the function
+   * limitJointWindup() above.
+   * @param ik_seed_state_fractions - A map from joint ids to fraction values in range [0,1]
+   * @return true on success, false if invalid entries are found (invalid joint id, value out of range)
+   */
   bool setIKSeedStateFractions(const std::map<size_t, double>& ik_seed_state_fractions);
 
+  /**
+   * @brief getIKSeedStateFractions - Get the currently specified ik_seed_state_fractions_ map.
+   * @return ik_seed_state_fractions_
+   */
   std::map<size_t, double> getIKSeedStateFractions() const;
 
   void updateRvizRobotState(const Eigen::Isometry3d &pose, const std::string &in_frame,

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -436,7 +436,7 @@ public:
   double getSpeedModifier(void) const;
 
   /**
-   * @brief limitJointWindup - Enable/Disable joint windup reduction in IK solutions by
+   * @brief setLimitJointWindup - Enable/Disable joint windup reduction in IK solutions by
    * applying the seed state modifiers defined in ik_seed_state_fractions_. The fraction values
    * are multiplied with the corresponding joint values in the seed state which causes IK solutions
    * to be "pulled" towards the center. Additionally the modified joints are solved with a lower
@@ -444,7 +444,12 @@ public:
    * affect the actual freedom of the joint but only centers IK solutions by a specified amount.
    * @param enabled - Set joint windup limitation feature on/off
    */
-  void limitJointWindup(bool enabled);
+  void setLimitJointWindup(bool enabled);
+
+  /**
+   * @brief getLimitJointWindup - query the robot class to determine if the limit_joint_windup_ flag is set
+   */
+  bool getLimitJointWindup();
 
   /**
    * @brief setIKSeedStateFractions - Specify joint value modifiers that should be applied in IK
@@ -583,10 +588,10 @@ protected:
   virtual std::vector<double> getJointState(void) const;
 
   bool getIK(const Eigen::Isometry3d pose, const std::vector<double> &seed,
-    std::vector<double> &joint_point, double timeout = 1, bool limit_joint_windup = false) const;
+    std::vector<double> &joint_point, double timeout = 1) const;
 
   bool getIK(const Eigen::Isometry3d pose, std::vector<double> &joint_point,
-    double timeout = 1, bool limit_joint_windup = false) const;
+    double timeout = 1) const;
 
   bool getFK(const std::vector<double> &joint_point, Eigen::Isometry3d &pose) const;
 
@@ -641,7 +646,7 @@ protected:
   std::string robot_description_;
 
   // Limit IK joint windup
-  bool limit_joint_windup_ = false;
+  bool limit_joint_windup_;
   std::map<size_t, double> ik_seed_state_fractions_;
 };
 } // namespace moveit_simple

--- a/moveit_simple/package.xml
+++ b/moveit_simple/package.xml
@@ -21,6 +21,7 @@
   <build_depend>moveit_core</build_depend>
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>moveit_visual_tools</build_depend>
+  <build_depend>random_numbers</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rosparam_handler</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -39,6 +40,7 @@
   <run_depend>industrial_robot_simulator</run_depend>
   <run_depend>moveit_core</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
+  <run_depend>random_numbers</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rosparam_handler</run_depend>

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -1251,14 +1251,15 @@ bool Robot::getIK(const Eigen::Isometry3d pose, std::vector<double>& joint_point
                   bool limit_joint_windup) const
 {
   Eigen::Isometry3d ik_tip_pose = pose * ik_tip_to_srdf_tip_;
-  std::vector<double> consistency_limit(6, 2 * M_PI);
+  std::vector<double> consistency_limit(6, 4 * M_PI);
   // we add a 'soft' consistency limit so that IK solutions can only converge slowly towards the joint limit
   if (limit_joint_windup && !ik_seed_state_fractions_.empty())
   {
     for (const std::pair<size_t, double>& seed_state_fraction : ik_seed_state_fractions_)
       consistency_limit[seed_state_fraction.first] = M_PI;
   }
-  if (virtual_robot_state_->setFromIK(joint_group_, ik_tip_pose, ik_tip_frame_, {consistency_limit}, timeout))
+  std::string ik_tip_frame = joint_group_->getSolverInstance()->getTipFrame();
+  if (virtual_robot_state_->setFromIK(joint_group_, ik_tip_pose, ik_tip_frame, {consistency_limit}, timeout))
   {
     virtual_robot_state_->copyJointGroupPositions(joint_group_->getName(), joint_point);
     virtual_robot_state_->update();

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -1252,7 +1252,7 @@ bool Robot::getIK(const Eigen::Isometry3d pose, std::vector<double>& joint_point
 {
   Eigen::Isometry3d ik_tip_pose = pose * ik_tip_to_srdf_tip_;
   std::vector<double> consistency_limit(6, 2 * M_PI);
-  // we add a 'soft' consistency limit that so that IK solutions can only converge slowly towards the joint limit
+  // we add a 'soft' consistency limit so that IK solutions can only converge slowly towards the joint limit
   if (limit_joint_windup && !ik_seed_state_fractions_.empty())
   {
     for (const std::pair<size_t, double>& seed_state_fraction : ik_seed_state_fractions_)

--- a/moveit_simple/test/launch/tool_windup_utest.launch
+++ b/moveit_simple/test/launch/tool_windup_utest.launch
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- Unit test launch file -->
+  <!-- The name of the parameter under which the URDF is loaded -->
+  <arg name="robot_description" default="robot_description"/>
+
+  <!-- Launch test node -->
+  <arg name="run_test_node" default="true"/>
+
+  <!-- Debug Info -->
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+
+  <include file="$(find moveit_simple)/test/launch/kuka_kr210.launch">
+    <arg name="robot_description" value="$(arg robot_description)"/>
+    <arg name="urdf_file" value="$(find moveit_simple)/test/resources/kuka_kr210/kr210l150.urdf"/>
+    <arg name="urdf_file_custom_tool" value="$(find moveit_simple)/test/resources/kuka_kr210/kuka_custom_tool.urdf"/>
+    <arg name="run_test_node" value="$(arg run_test_node)"/>
+  </include>
+
+  <!-- Test Node -->
+  <test test-name="tool_windup_utest" pkg="moveit_simple" type="tool_windup_utest"
+  launch-prefix="$(arg launch_prefix)" if="$(arg run_test_node)" time-limit="500.0"/>
+</launch>

--- a/moveit_simple/test/tool_windup.cpp
+++ b/moveit_simple/test/tool_windup.cpp
@@ -1,0 +1,149 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2019 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <eigen_conversions/eigen_msg.h>
+#include <gtest/gtest.h>
+#include <moveit_simple/moveit_simple.h>
+#include <moveit_simple/prettyprint.hpp>
+#include <random_numbers/random_numbers.h>
+
+using testing::Types;
+
+namespace moveit_simple_test
+{
+
+/**
+ * @brief UserRobotTest is a fixture for testing public methods.
+ * Objects that can be directly used inside the test
+ - robot pointer for moveit_simple::OnlineRobot
+*/
+class UserRobotTest : public ::testing::Test
+{
+protected:
+  std::unique_ptr<moveit_simple::OnlineRobot> robot;
+  virtual void SetUp()
+  {
+  robot = std::unique_ptr<moveit_simple::OnlineRobot> (new moveit_simple::OnlineRobot
+                  (ros::NodeHandle(), "robot_description", "manipulator"));
+  ros::Duration(2.0).sleep();  //wait for tf tree to populate
+  }
+  virtual void TearDown()
+  {}
+};
+
+/**
+ * @brief DeveloperRobot is a class inheriting from moveit_simple::OnlineRobot to test protected methods
+ * Add the protected methods(that are required to be tested) in the following list
+*/
+class DeveloperRobot: public moveit_simple::OnlineRobot
+{
+public:
+  using moveit_simple::OnlineRobot::OnlineRobot;
+  using moveit_simple::OnlineRobot::addTrajPoint;
+  using moveit_simple::OnlineRobot::toJointTrajectory;
+  using moveit_simple::OnlineRobot::interpolate;
+  using moveit_simple::OnlineRobot::jointInterpolation;
+  using moveit_simple::OnlineRobot::cartesianInterpolation;
+  using moveit_simple::OnlineRobot::isInCollision;
+};
+
+/**
+ * @brief DeveloperRobotTest is a fixture for testing protected methods.
+ * Objects that can be directly used inside the test
+ - robot pointer for DeveloperRobot
+*/
+
+class DeveloperRobotTest : public ::testing::Test
+{
+protected:
+  std::unique_ptr<DeveloperRobot> robot2;
+  virtual void SetUp()
+  {
+  robot2 = std::unique_ptr<DeveloperRobot> (new DeveloperRobot
+                  (ros::NodeHandle(), "robot_description", "manipulator"));
+  ros::Duration(2.0).sleep();  //wait for tf tree to populate
+  }
+  virtual void TearDown()
+  {}
+};
+
+TEST(MoveitSimpleTest, construction_robot)
+{
+  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");
+}
+
+TEST(MoveitSimpleTest, test_limit_ik_windup)
+{
+  ROS_INFO_STREAM("Testing IK solution of waypoint");
+  // initialize robot
+  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");
+
+  // run stepwise rotations and provoke windup
+  Eigen::Isometry3d pose(Eigen::Translation3d(Eigen::Vector3d(1.904, 0.000, 2.762)));
+  std::vector<double> joints(6,0);
+  double angle_step = 0.05;
+  size_t steps = 1.5 * M_PI / angle_step + 1;
+  for (size_t i = 0; i < steps; ++i)
+  {
+    pose.rotate(Eigen::AngleAxisd(angle_step, Eigen::Vector3d::UnitX()));
+    robot.getJointSolution(pose, "tool0", 0.01, joints, joints);
+  }
+  EXPECT_TRUE(std::abs(joints.back()) > 1.5 * M_PI);
+
+  // test getter and setter functions for ik_seed_state_fractions_
+  std::map<size_t, double> seed_fractions;
+  seed_fractions[6] = 0.1;  // invalid joint position
+  EXPECT_FALSE(robot.setIKSeedStateFractions(seed_fractions));
+  seed_fractions.clear();
+  seed_fractions[5] = 1.1;  // invalid fraction value
+  EXPECT_FALSE(robot.setIKSeedStateFractions(seed_fractions));
+  seed_fractions.clear();
+  // set ik seed state fractions to 'pull' wrist joint towards 0
+  seed_fractions[5] = 0.3;
+  EXPECT_TRUE(robot.setIKSeedStateFractions(seed_fractions));
+  EXPECT_TRUE(seed_fractions == robot.getIKSeedStateFractions());
+  // enable joint windup limitation
+  robot.limitJointWindup(true);
+
+  // run same rotations as before and verify that windup is disabled
+  pose.linear().setIdentity();
+  for (size_t i = 0; i < steps; ++i)
+  {
+    pose.rotate(Eigen::AngleAxisd(angle_step, Eigen::Vector3d::UnitX()));
+    robot.getJointSolution(pose, "tool0", 0.01, joints, joints);
+  }
+  EXPECT_FALSE(std::abs(joints.back()) > 1.5 * M_PI);
+
+  // stress test with 1000 consecutive random orientations while using the previous solution seed state
+  // this shouldn't produce any windup in the wrist joint at all (abs(value) < pi)
+  random_numbers::RandomNumberGenerator rand(7 /* seed */);
+  steps = 1000;
+  size_t failed_ik_count = 0;
+  size_t failed_windup_count = 0;
+  for (size_t i = 0; i < steps; ++i)
+  {
+    pose.rotate(Eigen::AngleAxisd(rand.uniformReal(-M_PI, M_PI), Eigen::Vector3d::UnitX()));
+    if (!robot.getJointSolution(pose, "tool0", 0.05, joints, joints))
+      ++failed_ik_count;
+    else if (std::abs(joints.back() > 1.5 * M_PI))
+      ++failed_windup_count;
+  }
+  EXPECT_TRUE(failed_ik_count == 0);
+  EXPECT_TRUE(failed_windup_count == 0);
+}
+}

--- a/moveit_simple/test/tool_windup.cpp
+++ b/moveit_simple/test/tool_windup.cpp
@@ -82,8 +82,11 @@ TEST(MoveitSimpleTest, test_limit_ik_windup)
   seed_fractions[5] = 0.3;
   EXPECT_TRUE(robot.setIKSeedStateFractions(seed_fractions));
   EXPECT_TRUE(seed_fractions == robot.getIKSeedStateFractions());
-  // enable joint windup limitation
-  robot.limitJointWindup(true);
+  // Test enable and disable joint windup limitation. (this should end with an enabled flag)
+  robot.setLimitJointWindup(false);
+  EXPECT_FALSE(robot.getLimitJointWindup());
+  robot.setLimitJointWindup(true);
+  EXPECT_TRUE(robot.getLimitJointWindup());
 
   // run same rotations as before and verify that windup is disabled
   pose.linear().setIdentity();

--- a/moveit_simple/test/tool_windup.cpp
+++ b/moveit_simple/test/tool_windup.cpp
@@ -47,61 +47,6 @@ using testing::Types;
 namespace moveit_simple_test
 {
 
-/**
- * @brief UserRobotTest is a fixture for testing public methods.
- * Objects that can be directly used inside the test
- - robot pointer for moveit_simple::OnlineRobot
-*/
-class UserRobotTest : public ::testing::Test
-{
-protected:
-  std::unique_ptr<moveit_simple::OnlineRobot> robot;
-  virtual void SetUp()
-  {
-  robot = std::unique_ptr<moveit_simple::OnlineRobot> (new moveit_simple::OnlineRobot
-                  (ros::NodeHandle(), "robot_description", "manipulator"));
-  ros::Duration(2.0).sleep();  //wait for tf tree to populate
-  }
-  virtual void TearDown()
-  {}
-};
-
-/**
- * @brief DeveloperRobot is a class inheriting from moveit_simple::OnlineRobot to test protected methods
- * Add the protected methods(that are required to be tested) in the following list
-*/
-class DeveloperRobot: public moveit_simple::OnlineRobot
-{
-public:
-  using moveit_simple::OnlineRobot::OnlineRobot;
-  using moveit_simple::OnlineRobot::addTrajPoint;
-  using moveit_simple::OnlineRobot::toJointTrajectory;
-  using moveit_simple::OnlineRobot::interpolate;
-  using moveit_simple::OnlineRobot::jointInterpolation;
-  using moveit_simple::OnlineRobot::cartesianInterpolation;
-  using moveit_simple::OnlineRobot::isInCollision;
-};
-
-/**
- * @brief DeveloperRobotTest is a fixture for testing protected methods.
- * Objects that can be directly used inside the test
- - robot pointer for DeveloperRobot
-*/
-
-class DeveloperRobotTest : public ::testing::Test
-{
-protected:
-  std::unique_ptr<DeveloperRobot> robot2;
-  virtual void SetUp()
-  {
-  robot2 = std::unique_ptr<DeveloperRobot> (new DeveloperRobot
-                  (ros::NodeHandle(), "robot_description", "manipulator"));
-  ros::Duration(2.0).sleep();  //wait for tf tree to populate
-  }
-  virtual void TearDown()
-  {}
-};
-
 TEST(MoveitSimpleTest, construction_robot)
 {
   moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");

--- a/moveit_simple/test/tool_windup.cpp
+++ b/moveit_simple/test/tool_windup.cpp
@@ -1,20 +1,40 @@
-/*
- * Software License Agreement (Apache License)
+/*********************************************************************
+ * Software License Agreement (BSD License)
  *
- * Copyright (c) 2019 Plus One Robotics
+ *  Copyright (c) 2019, PickNik LLC
+ *  All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Henning Kayser
+   Desc: Unit test cases for verifying tool windup limitation is functional
+*/
 
 #include <eigen_conversions/eigen_msg.h>
 #include <gtest/gtest.h>

--- a/moveit_simple/test/tool_windup_utest.cpp
+++ b/moveit_simple/test/tool_windup_utest.cpp
@@ -1,20 +1,40 @@
-/*
- * Software License Agreement (Apache License)
+/*********************************************************************
+ * Software License Agreement (BSD License)
  *
- * Copyright (c) 2019 Plus One Robotics
+ *  Copyright (c) 2019, PickNik LLC
+ *  All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Henning Kayser
+   Desc: Node for tool windup limitation unit tests (tool_windup.cpp)
+*/
 
 #include <gtest/gtest.h>
 #include <ros/ros.h>

--- a/moveit_simple/test/tool_windup_utest.cpp
+++ b/moveit_simple/test/tool_windup_utest.cpp
@@ -1,0 +1,34 @@
+/*
+ * Software License Agreement (Apache License)
+ *
+ * Copyright (c) 2019 Plus One Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+#include <boost/thread/thread.hpp>
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "tool_windup_utest");
+  boost::thread ros_thread(boost::bind(&ros::spin));
+
+  int res = RUN_ALL_TESTS();
+  ros_thread.interrupt();
+  ros_thread.join();
+
+  return res;
+}


### PR DESCRIPTION
This is the first part on limiting joint windup for single IK solutions by setting a "soft" joint limit that still allows exceeding it intentionally. It's based on setting a joint value modifier in range [0,1] that is multiplied with the IK seed state to "pull" desired joints towards the center. This works best in combination with minimal-distance IK solvers (like currently LMA). To eliminate outliers completely the consistency limit of specified joints is set to the lower value PI.

This method allows to preserve the full freedom of the joint since only the seed state is modified.
This allows for consecutive IK solutions to still move the full way if the steps are sufficiently small (i.e. for cartesian planning). For example a value of 0.5 would allow the joint value to converge to 2PI but only if sequential IK calls produce solutions within closest proximity. The closer the the value is to the limit the lower the distance needs to be to still move towards it. In practice this means that the actually reachable limit is considerably below that one. Lower fractions let the value converge to lower limits (I could make a table for that). A good value to limit wrist windup would be 0.3 or maybe even lower (~1.4PI limit).

The modifiers are stored in a map ik_seed_state_fractions_ and can only accessed by getter() and setter() functions that also test the validity of the values. The feature is enabled by calling robot.limitJointWindup(true) and is active for all getJointSolution() calls including waypoint conversions.

The test shows how this is applied to limit wrist joint windup by setting the corresponding fraction to 0.3.
I suggest specifying desired values either inside the kinematics.yaml or inside a new moveit_simple.yaml since I think this should be needed anyway.

This solution is meant to be used for all IK calls but does not support end effector symmetries.
For this a separate function will be needed anyway just as for separate pick/place state optimization.
I'm planning to do follow-up PRs for that so this one doesn't get bloated.