### PR TITLE
Support IK solutions with end effector symmetries

### DIFF
--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -610,6 +610,16 @@ protected:
   bool getIK(const Eigen::Isometry3d pose, std::vector<double> &joint_point,
     double timeout = 1) const;
 
+  /**
+   * @brief getSymmetricIK-
+   * @param   pose             - End effector pose for which to solve IK
+   * @param   seed             - Seed joint state to be passed into the IK solver
+   * @param   joint_values     - If successful, joint_values will be populated
+   * @param   result_diff_pose - Transform from the pose passed in to a symmetric pose
+   * @param   result_score     - Quality of the result. Larger numbers represent solutions closer to the seed state.
+   * @param   timeout          - The amount of time to allocate for the IK solver to find a solution
+   * @return  bool             - true on success
+   */
   bool getSymmetricIK(const Eigen::Isometry3d& pose, const std::vector<double>& seed, std::vector<double>& joint_values,
       Eigen::Isometry3d& result_diff_pose, double& result_score, double timeout) const;
 

--- a/moveit_simple/test/tool_windup.cpp
+++ b/moveit_simple/test/tool_windup.cpp
@@ -233,7 +233,7 @@ TEST_F(DeveloperRobotTest, test_symmetric_ik)
   std::map<size_t, double> seed_fractions;
   seed_fractions[5] = 0.0; // strongly 'pull' wrist joint towards 0
   EXPECT_TRUE(robot_->setIKSeedStateFractions(seed_fractions));
-  robot_->limitJointWindup(true);
+  robot_->setLimitJointWindup(true);
   random_numbers::RandomNumberGenerator rand(7 /* seed */);
   // wrist joint values should be below this threshold since symmetry allows it
   double orientation_threshold = M_PI / 4;

--- a/moveit_simple/test/tool_windup.cpp
+++ b/moveit_simple/test/tool_windup.cpp
@@ -46,54 +46,108 @@ using testing::Types;
 
 namespace moveit_simple_test
 {
+/**
+ * @brief UserRobotTest is a fixture for testing public methods.
+ * Objects that can be directly used inside the test
+ - robot pointer for moveit_simple::OnlineRobot
+*/
+class UserRobotTest : public ::testing::Test
+{
+protected:
+  std::unique_ptr<moveit_simple::OnlineRobot> robot_;
+  virtual void SetUp()
+  {
+    robot_ = std::unique_ptr<moveit_simple::OnlineRobot> (new moveit_simple::OnlineRobot
+                    (ros::NodeHandle(), "robot_description", "manipulator"));
+    ros::Duration(2.0).sleep();  //wait for tf tree to populate
+  }
+  virtual void TearDown()
+  {}
+};
+
+/**
+ * @brief DeveloperRobot is a class inheriting from moveit_simple::OnlineRobot to test protected methods
+ * Add the protected methods(that are required to be tested) in the following list
+*/
+class DeveloperRobot: public moveit_simple::OnlineRobot
+{
+public:
+  using moveit_simple::OnlineRobot::OnlineRobot;
+  using moveit_simple::OnlineRobot::addTrajPoint;
+  using moveit_simple::OnlineRobot::toJointTrajectory;
+  using moveit_simple::OnlineRobot::interpolate;
+  using moveit_simple::OnlineRobot::jointInterpolation;
+  using moveit_simple::OnlineRobot::cartesianInterpolation;
+  using moveit_simple::OnlineRobot::isInCollision;
+  using moveit_simple::OnlineRobot::getSymmetricIK;
+};
+
+/**
+ * @brief DeveloperRobotTest is a fixture for testing protected methods.
+ * Objects that can be directly used inside the test
+ - robot pointer for DeveloperRobot
+*/
+
+class DeveloperRobotTest : public ::testing::Test
+{
+protected:
+  std::unique_ptr<DeveloperRobot> robot_;
+  virtual void SetUp()
+  {
+    robot_ = std::unique_ptr<DeveloperRobot> (new DeveloperRobot
+                    (ros::NodeHandle(), "robot_description", "manipulator"));
+    ros::Duration(2.0).sleep();  //wait for tf tree to populate
+  }
+  virtual void TearDown()
+  {}
+};
 
 TEST(MoveitSimpleTest, construction_robot)
 {
   moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");
 }
 
-TEST(MoveitSimpleTest, test_limit_ik_windup)
+TEST_F(UserRobotTest, test_limit_ik_windup)
 {
   ROS_INFO_STREAM("Testing IK solution of waypoint");
-  // initialize robot
-  moveit_simple::Robot robot(ros::NodeHandle(), "robot_description", "manipulator");
 
   // run stepwise rotations and provoke windup
-  Eigen::Isometry3d pose(Eigen::Translation3d(Eigen::Vector3d(1.904, 0.000, 2.762)));
+  Eigen::Isometry3d pose(Eigen::Translation3d(Eigen::Vector3d(2, 0, 2.5)));
   std::vector<double> joints(6,0);
   double angle_step = 0.05;
   size_t steps = 1.5 * M_PI / angle_step + 1;
   for (size_t i = 0; i < steps; ++i)
   {
     pose.rotate(Eigen::AngleAxisd(angle_step, Eigen::Vector3d::UnitX()));
-    robot.getJointSolution(pose, "tool0", 0.01, joints, joints);
+    robot_->getJointSolution(pose, "tool0", 0.01, joints, joints);
   }
   EXPECT_TRUE(std::abs(joints.back()) > 1.5 * M_PI);
 
   // test getter and setter functions for ik_seed_state_fractions_
   std::map<size_t, double> seed_fractions;
   seed_fractions[6] = 0.1;  // invalid joint position
-  EXPECT_FALSE(robot.setIKSeedStateFractions(seed_fractions));
+  EXPECT_FALSE(robot_->setIKSeedStateFractions(seed_fractions));
   seed_fractions.clear();
   seed_fractions[5] = 1.1;  // invalid fraction value
-  EXPECT_FALSE(robot.setIKSeedStateFractions(seed_fractions));
+  EXPECT_FALSE(robot_->setIKSeedStateFractions(seed_fractions));
   seed_fractions.clear();
   // set ik seed state fractions to 'pull' wrist joint towards 0
   seed_fractions[5] = 0.3;
-  EXPECT_TRUE(robot.setIKSeedStateFractions(seed_fractions));
-  EXPECT_TRUE(seed_fractions == robot.getIKSeedStateFractions());
+  EXPECT_TRUE(robot_->setIKSeedStateFractions(seed_fractions));
+  EXPECT_TRUE(seed_fractions == robot_->getIKSeedStateFractions());
+
   // Test enable and disable joint windup limitation. (this should end with an enabled flag)
-  robot.setLimitJointWindup(false);
-  EXPECT_FALSE(robot.getLimitJointWindup());
-  robot.setLimitJointWindup(true);
-  EXPECT_TRUE(robot.getLimitJointWindup());
+  robot_->setLimitJointWindup(false);
+  EXPECT_FALSE(robot_->getLimitJointWindup());
+  robot_->setLimitJointWindup(true);
+  EXPECT_TRUE(robot_->getLimitJointWindup());
 
   // run same rotations as before and verify that windup is disabled
   pose.linear().setIdentity();
   for (size_t i = 0; i < steps; ++i)
   {
     pose.rotate(Eigen::AngleAxisd(angle_step, Eigen::Vector3d::UnitX()));
-    robot.getJointSolution(pose, "tool0", 0.01, joints, joints);
+    robot_->getJointSolution(pose, "tool0", 0.01, joints, joints);
   }
   EXPECT_FALSE(std::abs(joints.back()) > 1.5 * M_PI);
 
@@ -106,12 +160,89 @@ TEST(MoveitSimpleTest, test_limit_ik_windup)
   for (size_t i = 0; i < steps; ++i)
   {
     pose.rotate(Eigen::AngleAxisd(rand.uniformReal(-M_PI, M_PI), Eigen::Vector3d::UnitX()));
-    if (!robot.getJointSolution(pose, "tool0", 0.05, joints, joints))
+    if (!robot_->getJointSolution(pose, "tool0", 0.05, joints, joints))
       ++failed_ik_count;
     else if (std::abs(joints.back() > 1.5 * M_PI))
       ++failed_windup_count;
   }
   EXPECT_TRUE(failed_ik_count == 0);
   EXPECT_TRUE(failed_windup_count == 0);
+}
+
+TEST_F(DeveloperRobotTest, test_symmetric_ik)
+{
+  // init target pose and a target state IK solution
+  Eigen::Isometry3d pose(Eigen::Translation3d(Eigen::Vector3d(2, 0, 2.5)));
+  std::vector<double> joint_state = robot_->getJointState();
+  ASSERT_TRUE(robot_->getJointSolution(pose, 0.1, joint_state, joint_state));
+  std::vector<double> seed = joint_state;  // init target state as seed
+
+  // test free rotation around z (circular end effector)
+  robot_->setEndEffectorSymmetry(moveit_simple::EndEffectorSymmetry::Circular);
+  double distance_threshold = 0.05; // total joint value distance shouldn't exceed this value
+  double max_distance = 0.0;
+  constexpr size_t steps = 10;
+  for (size_t i = 0; i < steps; ++i)
+  {
+    pose.rotate(Eigen::AngleAxisd(2 * M_PI / steps, Eigen::Vector3d::UnitX()));
+    ASSERT_TRUE(robot_->getJointSolution(pose, 0.1, seed, joint_state, true));
+    double distance = 0;
+    for (size_t j = 0; j < seed.size(); ++j)
+      distance += std::abs(joint_state[j] - seed[j]);
+    if (distance > max_distance)
+      max_distance = distance;
+  }
+  EXPECT_TRUE(max_distance < distance_threshold);
+
+  // test 1 symmetry around z (rectangular end effector)
+  robot_->setEndEffectorSymmetry(moveit_simple::EndEffectorSymmetry::Rectangular);
+  distance_threshold = M_PI / 2; // total joint value distance shouldn't exceed this value
+  max_distance = 0.0;
+  for (size_t i = 0; i < steps; ++i)
+  {
+    pose.rotate(Eigen::AngleAxisd(2 * M_PI / steps, Eigen::Vector3d::UnitX()));
+    ASSERT_TRUE(robot_->getJointSolution(pose, 0.1, seed, joint_state, true));
+    double distance = 0;
+    for (size_t j = 0; j < seed.size(); ++j)
+      distance += std::abs(joint_state[j] - seed[j]);
+    if (distance > max_distance)
+      max_distance = distance;
+  }
+  EXPECT_TRUE(max_distance < distance_threshold);
+
+  // test 2 symmetries around z (square end effector)
+  robot_->setEndEffectorSymmetry(moveit_simple::EndEffectorSymmetry::Quadratic);
+  distance_threshold =  M_PI / 4; // total joint value distance shouldn't exceed this value
+  max_distance = 0.0;
+  for (size_t i = 0; i < steps; ++i)
+  {
+    pose.rotate(Eigen::AngleAxisd(2 * M_PI / steps, Eigen::Vector3d::UnitX()));
+    ASSERT_TRUE(robot_->getJointSolution(pose, 0.1, seed, joint_state, true));
+    double distance = 0;
+    for (size_t j = 0; j < seed.size(); ++j)
+      distance += std::abs(joint_state[j] - seed[j]);
+    if (distance > max_distance)
+      max_distance = distance;
+  }
+  EXPECT_TRUE(max_distance < distance_threshold);
+
+  // Test symmetric Ik in combination with joint windup reduction
+  // The last wrist joint is set to 2*MPI while the seed fraction is set to 0.
+  // Random target pose orientations should generate IK solutions that are below
+  // the orientation threshold of the corresponding symmetry.
+  std::map<size_t, double> seed_fractions;
+  seed_fractions[5] = 0.0; // strongly 'pull' wrist joint towards 0
+  EXPECT_TRUE(robot_->setIKSeedStateFractions(seed_fractions));
+  robot_->limitJointWindup(true);
+  random_numbers::RandomNumberGenerator rand(7 /* seed */);
+  // wrist joint values should be below this threshold since symmetry allows it
+  double orientation_threshold = M_PI / 4;
+  seed[5] = 2 * M_PI;  // seed wrist joint value is 2 * M_PI
+  for (size_t i = 0; i < 1000; ++i)
+  {
+    pose.rotate(Eigen::AngleAxisd(rand.uniformReal(-M_PI, M_PI), Eigen::Vector3d::UnitX()));
+    ASSERT_TRUE(robot_->getJointSolution(pose, 0.1, seed, joint_state, true));
+    ASSERT_TRUE(std::abs(joint_state[5]) < orientation_threshold);
+  }
 }
 }


### PR DESCRIPTION
As discussed in https://github.com/plusone-robotics/moveit_simple/issues/79 pick and place poses should be computed such that tool windup (or joint windup in general) is reduced as much as possible.
With symmetric end effectors (circular, rectangular, square) it's possible to rotate the grasp pose while still producing valid grasps. This extended IK wrapper function adds support for computing IK solutions for all three end effector types and also optionally applies the tool windup reduction feature introduced in #89.