### PR TITLE
Simple combined pick/place IK supporting symmetries

### DIFF
--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -356,6 +356,41 @@ public:
     const std::vector<double> &seed, std::vector<double> &joint_point, bool symmetric_solution = false) const;
 
   /**
+   * @brief getPickPlaceJointSolutions computes IK solutions for pick and place poses of a desired object.
+   * The pick pose is computed with symmetric IK solutions so that joint windup and displacement is minimized
+   * as much as possible. The place pose is solved by simple IK with applied orientation offset of the pick pose.
+   * @param pick_pose - the desired pick pose of the object (the grasp pose, not the object pose)
+   * @param place_pose - the desired place pose of the object (the grasp pose, not the object pose)
+   * @param reference_frame - the frame of pick_pose and place_pose
+   * @param timeout - the solver timeout in seconds
+   * @param seed - the seed state to use for IK, if empty the current state is used
+   * @param pick_joint_state - returns the joint state solution for pick_pose
+   * @param place_joint_state - returns the joint state solution for place_pose
+   * @return true if joint solutions found
+   */
+  bool getPickPlaceJointSolutions(const Eigen::Isometry3d& pick_pose, const Eigen::Isometry3d& place_pose,
+                                  const std::string& reference_frame, double timeout,
+                                  const std::vector<double>& seed, std::vector<double>& pick_joint_state,
+                                  std::vector<double>& place_joint_state) const;
+
+  /**
+   * @brief getPickPlaceJointSolutions computes IK solutions for pick and place poses of a desired object.
+   * The pick pose is computed with symmetric IK solutions so that joint windup and displacement is minimized
+   * as much as possible. The place pose is solved by simple IK with applied orientation offset of the pick pose.
+   * @param pick_pose - the desired pick pose of the object (the grasp pose, not the object pose)
+   * @param place_pose - the desired place pose of the object (the grasp pose, not the object pose)
+   * @param timeout - the solver timeout in seconds
+   * @param seed - the seed state to use for IK, if empty the current state is used
+   * @param pick_joint_state - returns the joint state solution for pick_pose
+   * @param place_joint_state - returns the joint state solution for place_pose
+   * @return true if joint solutions found
+   */
+  bool getPickPlaceJointSolutions(const Eigen::Isometry3d& pick_pose, const Eigen::Isometry3d& place_pose,
+                                  double timeout, const std::vector<double>& seed,
+                                  std::vector<double>& pick_joint_state,
+                                  std::vector<double>& place_joint_state) const;
+
+  /**
    * @brief getPose finds cartesian pose for the given joint positions.
    * @param joint_point - joint positions
    * @param pose - pose corresponding to joint_pose

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -552,7 +552,7 @@ bool Robot::getPickPlaceJointSolutions(const Eigen::Isometry3d& pick_pose, const
     ROS_ERROR("Ran out of time computing pick and place joint solutions");
     return false;
   }
-  if (!getIK(place_pose * pick_pose_diff, pick_joint_state, place_joint_state, timeout, limit_joint_windup_))
+  if (!getIK(place_pose * pick_pose_diff, pick_joint_state, place_joint_state, timeout))
   {
     ROS_ERROR_STREAM("Unable to find IK solution for place pose");
     return false;
@@ -1329,7 +1329,7 @@ bool Robot::getIK(const Eigen::Isometry3d pose, const std::vector<double>& seed,
 bool Robot::getIK(const Eigen::Isometry3d pose, std::vector<double>& joint_point, double timeout) const
 {
   Eigen::Isometry3d ik_tip_pose = pose * ik_tip_to_srdf_tip_;
-  std::vector<double> consistency_limit(6, 4 * M_PI);
+  std::vector<double> consistency_limit(joint_group_->getActiveJointModels().size(), 4 * M_PI);
   // we add a 'soft' consistency limit so that IK solutions can only converge slowly towards the joint limit
   if (limit_joint_windup_ && !ik_seed_state_fractions_.empty())
   {
@@ -1407,7 +1407,7 @@ bool Robot::getSymmetricIK(const Eigen::Isometry3d& pose, const std::vector<doub
 
   // init local seed and consistency limit for windup reduction
   std::vector<double> local_seed(seed);
-  std::vector<double> consistency_limit(6, 4 * M_PI);
+  std::vector<double> consistency_limit(joint_group_->getActiveJointModels().size(), 4 * M_PI);
   if (limit_joint_windup_)
   {
     for (const std::pair<size_t, double> seed_state_fraction : ik_seed_state_fractions_)


### PR DESCRIPTION
Based on #90 this PR adds a simple function `getPickPlaceJointSolutions()` that computes IK solutions for pick and place poses while optimizing for symmetric end effectors. This first implementation uses `getSymmetricIK()` for searching the grasp state and then uses the orientation offset to compute the place joint state via normal IK.