### PR TITLE
Reintroduce optional parameter limit_joint_windup to getIK()

### DIFF
--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -640,10 +640,10 @@ protected:
   virtual std::vector<double> getJointState(void) const;
 
   bool getIK(const Eigen::Isometry3d pose, const std::vector<double> &seed,
-    std::vector<double> &joint_point, double timeout = 1) const;
+    std::vector<double> &joint_point, double timeout = 1, bool limit_joint_windup = false) const;
 
   bool getIK(const Eigen::Isometry3d pose, std::vector<double> &joint_point,
-    double timeout = 1) const;
+    double timeout = 1, bool limit_joint_windup = false) const;
 
   /**
    * @brief getSymmetricIK-


### PR DESCRIPTION
This adds the default parameter limit_joint_windup to getIK() for enabling/disabling this featuer for low-level IK calls. This is necessary for instance when computing constrained IK solutions like pick/place poses (https://github.com/plusone-robotics/moveit_simple/pull/91).