### PR TITLE
Added reconstruct_pose method to robot.cpp

### DIFF
--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -569,7 +569,7 @@ protected:
    * @param pose
    * @return reconstructed pose
    */
-  Eigen::Affine3d reconstruct_pose(const Eigen::Affine3d &pose) const;
+  Eigen::Affine3d reconstructPose(const Eigen::Affine3d &pose) const;
 
   bool getFK(const std::vector<double> &joint_point, Eigen::Affine3d &pose) const;
 

--- a/moveit_simple/include/moveit_simple/robot.h
+++ b/moveit_simple/include/moveit_simple/robot.h
@@ -562,6 +562,15 @@ protected:
   bool getIK(const Eigen::Affine3d pose, std::vector<double> &joint_point,
     double timeout = 1, unsigned int attempts = 1) const;
 
+  /**
+   * @brief reconstructs a pose from its constituent translation and rotation.
+   * This is necessary to do when the pose matrix is unsolvable for IK
+   * Reconstructing the pose matrix created an equivalent but solvable matrix
+   * @param pose
+   * @return reconstructed pose
+   */
+  Eigen::Affine3d reconstruct_pose(const Eigen::Affine3d &pose) const;
+
   bool getFK(const std::vector<double> &joint_point, Eigen::Affine3d &pose) const;
 
   std::unique_ptr<TrajectoryPoint> lookupTrajectoryPoint(const std::string &name,

--- a/moveit_simple/src/robot.cpp
+++ b/moveit_simple/src/robot.cpp
@@ -1511,7 +1511,7 @@ bool Robot::getIK(const Eigen::Affine3d pose, const std::vector<double>& seed, s
 bool Robot::getIK(const Eigen::Affine3d pose, std::vector<double>& joint_point, double timeout,
                   unsigned int attempts) const
 {
-  Eigen::Affine3d pose_reconstructed = reconstruct_pose(pose);
+  Eigen::Affine3d pose_reconstructed = reconstructPose(pose);
   Eigen::Affine3d ik_tip_pose_reconstructed = pose_reconstructed * ik_tip_to_srdf_tip_;
 
   if (virtual_robot_state_->setFromIK(joint_group_, ik_tip_pose_reconstructed, attempts, timeout))
@@ -1528,7 +1528,7 @@ bool Robot::getIK(const Eigen::Affine3d pose, std::vector<double>& joint_point, 
   return false;
 }
 
-Eigen::Affine3d Robot::reconstruct_pose(const Eigen::Affine3d &pose) const {
+Eigen::Affine3d Robot::reconstructPose(const Eigen::Affine3d &pose) const {
   Eigen::Affine3d pose_reconstructed;
 
   auto pose_rotation = pose.rotation().eulerAngles(0, 1, 2);


### PR DESCRIPTION
This pull request adds code to reconstruct the pose matrix just before solving IK. This fixes a bug that occured when performing remote picks, where the pick pose failed IK.

Pre-fix log:
```
[ WARN] [1567615434.802556808] [/controller]: Failed to find joint solution for point: dp_offset
[ WARN] [1567615434.802599713] [/controller]: Failed to convert trajectory point:  (dp_offset), of type: 2 to joint trajectory
[ERROR] [1567615434.802618994] [/controller]: Conversion to joint trajectory failed for pick due to IK failure of dp_offset
[ERROR] [1567615434.802635465] [/controller]: Failed to convert [pick] to joint trajectory
[ERROR] [1567615434.802739161] [/controller]: IK Failed for trajectory: [pick]
[ERROR] [1567615434.802797739] [/controller]: Failed to execute trajectory because of unexpected exception: Conversion to joint trajectory failed for pick
```

Post-fix log:
```
[ INFO] [1567615674.710997250] [/controller]: Found proper IK (no config change) in 1 attempts
[ INFO] [1567615674.711063509] [/controller]: 1 points among 1 successfully interpolated for dp_offset
[ INFO] [1567615674.711082765] [/controller]: Appending trajectory point, size: 3
[ INFO] [1567615674.711096600] [/controller]: Trajectory successfully added till dp_offset
```